### PR TITLE
Hca returns loss

### DIFF
--- a/rl_credit/__init__.py
+++ b/rl_credit/__init__.py
@@ -1,3 +1,3 @@
-from rl_credit.algos import A2CAlgo, PPOAlgo
-from rl_credit.model import ACModel, RecurrentACModel
+from rl_credit.algos import A2CAlgo, PPOAlgo, HCAReturns
+from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla
 from rl_credit.utils import DictList

--- a/rl_credit/__init__.py
+++ b/rl_credit/__init__.py
@@ -1,3 +1,3 @@
 from rl_credit.algos import A2CAlgo, PPOAlgo, HCAReturns
-from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla
+from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla, ACModelReturnHCA
 from rl_credit.utils import DictList

--- a/rl_credit/algos/__init__.py
+++ b/rl_credit/algos/__init__.py
@@ -1,2 +1,3 @@
 from rl_credit.algos.a2c import A2CAlgo
 from rl_credit.algos.ppo import PPOAlgo
+from rl_credit.algos.hca_returns import HCAReturns

--- a/rl_credit/algos/hca_returns.py
+++ b/rl_credit/algos/hca_returns.py
@@ -1,0 +1,72 @@
+import numpy
+import torch
+import torch.nn.functional as F
+
+from rl_credit.algos.base import BaseAlgo
+
+
+class HCAReturns(BaseAlgo):
+    """The Advantage Actor-Critic algorithm."""
+
+    def __init__(self, envs, acmodel, device=None, num_frames_per_proc=None, discount=0.99, lr=0.01, gae_lambda=0.95,
+                 entropy_coef=0.01, value_loss_coef=0.5, max_grad_norm=0.5, recurrence=1,
+                 rmsprop_alpha=0.99, rmsprop_eps=1e-8, preprocess_obss=None, reshape_reward=None):
+
+        if recurrence != 1:
+            raise ValueError("Memory is not supported for HCAReturns, recurrence must be 1.")
+        num_frames_per_proc = num_frames_per_proc or 8
+
+        super().__init__(envs, acmodel, device, num_frames_per_proc, discount, lr, gae_lambda, entropy_coef,
+                         value_loss_coef, max_grad_norm, recurrence, preprocess_obss, reshape_reward)
+
+        self.optimizer = torch.optim.RMSprop(self.acmodel.parameters(), lr,
+                                             alpha=rmsprop_alpha, eps=rmsprop_eps)
+
+    def update_parameters(self, exps):
+        # Initialize update values
+
+        update_entropy = 0
+        update_value = 0
+        update_policy_loss = 0
+        update_value_loss = 0
+        update_loss = 0
+
+        # Compute loss
+
+        dist, value = self.acmodel(exps.obs)
+
+        entropy = dist.entropy().mean()
+
+        policy_loss = -(dist.log_prob(exps.action) * exps.advantage).mean()
+
+        value_loss = (value - exps.returnn).pow(2).mean()
+
+        loss = policy_loss - self.entropy_coef * entropy + self.value_loss_coef * value_loss
+
+        # Update batch values
+
+        update_entropy += entropy.item()
+        update_value += value.mean().item()
+        update_policy_loss += policy_loss.item()
+        update_value_loss += value_loss.item()
+        update_loss += loss
+
+        # Update actor-critic
+
+        self.optimizer.zero_grad()
+        update_loss.backward()
+        update_grad_norm = sum(p.grad.data.norm(2) ** 2 for p in self.acmodel.parameters()) ** 0.5
+        torch.nn.utils.clip_grad_norm_(self.acmodel.parameters(), self.max_grad_norm)
+        self.optimizer.step()
+
+        # Log some values
+
+        logs = {
+            "entropy": update_entropy,
+            "value": update_value,
+            "policy_loss": update_policy_loss,
+            "value_loss": update_value_loss,
+            "grad_norm": update_grad_norm
+        }
+
+        return logs

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -134,3 +134,55 @@ class ACModel(nn.Module, RecurrentACModel):
     def _get_embed_text(self, text):
         _, hidden = self.text_rnn(self.word_embedding(text))
         return hidden[-1]
+
+
+# No memory, no text
+class ACModelVanilla(nn.Module, BaseModel):
+    def __init__(self, obs_space, action_space):
+        super().__init__()
+
+        # Define image embedding
+        self.image_conv = nn.Sequential(
+            nn.Conv2d(3, 16, (2, 2)),
+            nn.ReLU(),
+            nn.MaxPool2d((2, 2)),
+            nn.Conv2d(16, 32, (2, 2)),
+            nn.ReLU(),
+            nn.Conv2d(32, 64, (2, 2)),
+            nn.ReLU()
+        )
+        n = obs_space["image"][0]
+        m = obs_space["image"][1]
+        self.image_embedding_size = ((n-1)//2-2)*((m-1)//2-2)*64
+
+        # Define actor's model
+        self.actor = nn.Sequential(
+            nn.Linear(self.image_embedding_size, 64),
+            nn.Tanh(),
+            nn.Linear(64, action_space.n)
+        )
+
+        # Define critic's model
+        self.critic = nn.Sequential(
+            nn.Linear(self.image_embedding_size, 64),
+            nn.Tanh(),
+            nn.Linear(64, 1)
+        )
+
+        # Initialize parameters correctly
+        self.apply(init_params)
+
+    def forward(self, obs):
+        x = obs.image.transpose(1, 3).transpose(2, 3)
+        x = self.image_conv(x)
+        x = x.reshape(x.shape[0], -1)
+
+        embedding = x
+
+        x = self.actor(embedding)
+        dist = Categorical(logits=F.log_softmax(x, dim=1))
+
+        x = self.critic(embedding)
+        value = x.squeeze(1)
+
+        return dist, value

--- a/rl_credit/scripts/train.py
+++ b/rl_credit/scripts/train.py
@@ -7,7 +7,7 @@ import tensorboardX
 import sys
 
 import script_utils as utils
-from model import ACModel
+from model import ACModel, ACModelVanilla
 
 
 # Parse arguments
@@ -118,7 +118,10 @@ txt_logger.info("Observations preprocessor loaded")
 
 # Load model
 
-acmodel = ACModel(obs_space, envs[0].action_space, args.mem, args.text)
+if args.algo == "hca_returns":
+    acmodel = ACModelVanilla(obs_space, envs[0].action_space)
+else:
+    acmodel = ACModel(obs_space, envs[0].action_space, args.mem, args.text)
 if "model_state" in status:
     acmodel.load_state_dict(status["model_state"])
 acmodel.to(device)
@@ -135,6 +138,10 @@ elif args.algo == "ppo":
     algo = rl_credit.PPOAlgo(envs, acmodel, device, args.frames_per_proc, args.discount, args.lr, args.gae_lambda,
                             args.entropy_coef, args.value_loss_coef, args.max_grad_norm, args.recurrence,
                             args.optim_eps, args.clip_eps, args.epochs, args.batch_size, preprocess_obss)
+elif args.algo == "hca_returns":
+    algo = rl_credit.HCAReturns(envs, acmodel, device, args.frames_per_proc, args.discount, args.lr, args.gae_lambda,
+                            args.entropy_coef, args.value_loss_coef, args.max_grad_norm, args.recurrence,
+                            args.optim_alpha, args.optim_eps, preprocess_obss)
 else:
     raise ValueError("Incorrect algorithm name: {}".format(args.algo))
 

--- a/rl_credit/scripts/train.py
+++ b/rl_credit/scripts/train.py
@@ -7,7 +7,7 @@ import tensorboardX
 import sys
 
 import script_utils as utils
-from model import ACModel, ACModelVanilla
+from model import ACModel, ACModelVanilla, ACModelReturnHCA
 
 
 # Parse arguments
@@ -119,7 +119,7 @@ txt_logger.info("Observations preprocessor loaded")
 # Load model
 
 if args.algo == "hca_returns":
-    acmodel = ACModelVanilla(obs_space, envs[0].action_space)
+    acmodel = ACModelReturnHCA(obs_space, envs[0].action_space)
 else:
     acmodel = ACModel(obs_space, envs[0].action_space, args.mem, args.text)
 if "model_state" in status:


### PR DESCRIPTION
- Adds two actor critics (1) vanilla (simplifies old interface by stripping out all text/rnn code) (2) hca returns model including an hca returns head
- Adds beginning of HCA returns algo -- learns HCA fxn but doesn't actually use it to affect the policy gradient directly. (training "works" on current code).

TODO in future PR: use HCA to modify policy gradient