### PR TITLE
Hca returns

### DIFF
--- a/rl_credit/script_utils/agent.py
+++ b/rl_credit/script_utils/agent.py
@@ -1,7 +1,7 @@
 import torch
 
 import script_utils as utils
-from model import ACModel
+from model import ACModel, ACModelReturnHCA
 
 
 class Agent:
@@ -12,9 +12,12 @@ class Agent:
     - to analyze the feedback (i.e. reward and done state) of its action."""
 
     def __init__(self, obs_space, action_space, model_dir,
-                 device=None, argmax=False, num_envs=1, use_memory=False, use_text=False):
+                 device=None, argmax=False, num_envs=1, use_memory=False, use_text=False, hca_returns=False):
         obs_space, self.preprocess_obss = utils.get_obss_preprocessor(obs_space)
-        self.acmodel = ACModel(obs_space, action_space, use_memory=use_memory, use_text=use_text)
+        if hca_returns:
+            self.acmodel = ACModelReturnHCA(obs_space, action_space)
+        else:
+            self.acmodel = ACModel(obs_space, action_space, use_memory=use_memory, use_text=use_text)
         self.device = device
         self.argmax = argmax
         self.num_envs = num_envs

--- a/rl_credit/scripts/visualize.py
+++ b/rl_credit/scripts/visualize.py
@@ -29,6 +29,8 @@ parser.add_argument("--memory", action="store_true", default=False,
                     help="add a LSTM to the model")
 parser.add_argument("--text", action="store_true", default=False,
                     help="add a GRU to the model")
+parser.add_argument("--hcareturns", action="store_true", default=False,
+                    help="use HCA returns model")
 
 args = parser.parse_args()
 
@@ -52,7 +54,7 @@ print("Environment loaded\n")
 
 model_dir = utils.get_model_dir(args.model)
 agent = utils.Agent(env.observation_space, env.action_space, model_dir,
-                    device=device, argmax=args.argmax, use_memory=args.memory, use_text=args.text)
+                    device=device, argmax=args.argmax, use_memory=args.memory, use_text=args.text, hca_returns=args.hcareturns)
 print("Agent loaded\n")
 
 # Run the agent


### PR DESCRIPTION
Finish implementing HCA returns algorithm ==> modifies policy gradient advantage function by replacing it with hca factor.  Tried training baseline (no memory) and HCA returns over 1 million frames on `MiniGrid-KeyGiftsDoor-tiny-v0` environment.  Baseline does better since it learns to pick up the key in P1 and use it to open door in P3 to get to goal.  HCA return does not learn to pick up the key within 1 million steps.

TODO: figure out if there is a bug, or if HCA is just higher variance than the baseline (e.g. consider clipping the 1-pi/hca factor????).