### PR TITLE
Normalize the advantage in base.py

### DIFF
--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -212,6 +212,8 @@ class BaseAlgo(ABC):
         exps.value = self.values.transpose(0, 1).reshape(-1)
         exps.reward = self.rewards.transpose(0, 1).reshape(-1)
         exps.advantage = self.advantages.transpose(0, 1).reshape(-1)
+        # normalize the advantage
+        exps.advantage = (exps.advantage - exps.advantage.mean())/exps.advantage.std()
         exps.returnn = exps.value + exps.advantage
         exps.log_prob = self.log_probs.transpose(0, 1).reshape(-1)
 


### PR DESCRIPTION
Normalize the advantage like spin up does [here](https://github.com/openai/spinningup/blob/master/spinup/algos/pytorch/ppo/ppo.py#L81).

Tried training a2c with memory in same env over 1 million frames w/ and w/o normalizing advantage.  Notice the mean number of frames it takes to reach goal w/ normalized advantage is almost 1/4 of the frames for unnormalized.

last logs w/o advantage:
```
U 487 | F 997376 | FPS 1718 | D 473 | rR:μσmM 3.09 1.20 0.00 3.94 | F:μσmM 204.2 117.6 23.0 360.0 | H 1.717 | V 3.040 | pL -0.248 | vL 0.607 | ∇ 0.661
U 488 | F 999424 | FPS 1773 | D 474 | rR:μσmM 3.12 1.21 0.00 3.92 | F:μσmM 192.8 110.8 32.0 360.0 | H 1.718 | V 3.011 | pL 0.339 | vL 0.289 | ∇ 0.843
U 489 | F 1001472 | FPS 1708 | D 475 | rR:μσmM 3.41 0.69 0.86 3.90 | F:μσmM 162.2 91.9 41.0 308.0 | H 1.706 | V 3.183 | pL 0.111 | vL 0.293 | ∇ 0.340
```

last logs w/ advantage:
```
U 487 | F 997376 | FPS 1763 | D 476 | rR:μσmM 3.60 0.92 0.85 3.97 | F:μσmM 36.1 23.8 13.0 117.0 | H 1.327 | V -0.730 | pL -0.058 | vL 1.000 | ∇ 0.742
U 488 | F 999424 | FPS 2145 | D 477 | rR:μσmM 3.45 1.07 0.78 3.97 | F:μσmM 43.3 27.8 13.0 167.0 | H 1.331 | V -0.742 | pL 0.016 | vL 1.000 | ∇ 1.204
U 489 | F 1001472 | FPS 2277 | D 478 | rR:μσmM 3.37 1.17 0.61 3.97 | F:μσmM 39.4 28.4 13.0 155.0 | H 1.390 | V -0.786 | pL 0.023 | vL 1.000 | ∇ 0.603
```