### PR TITLE
Hca wandb log

### DIFF
--- a/rl_credit/algos/hca_returns.py
+++ b/rl_credit/algos/hca_returns.py
@@ -36,6 +36,15 @@ class HCAReturns(BaseAlgo):
             pi_hca_ratio = torch.exp(exps.log_prob) / hca_prob
             hca_factor = (1 - pi_hca_ratio) * exps.returnn
 
+            # for logging
+            hca_mean = hca_factor.mean().item()
+            hca_std = hca_factor.std().item()
+            adv_mean = exps.advantage.mean().item()
+            adv_std = exps.advantage.std().item()
+
+            pearson_corr = ((hca_factor - hca_mean) * (exps.advantage - adv_mean)).mean() \
+                           / (hca_std * adv_std)
+            logs['hca_adv_corr'] = pearson_corr.item()
             logs['hca_prob_max'] = hca_prob.max().item()
             logs['hca_prob_min'] = hca_prob.min().item()
             logs['hca_prob_mean'] = hca_prob.mean().item()
@@ -77,7 +86,12 @@ class HCAReturns(BaseAlgo):
             "hca_loss": hca_loss.item(),
             "hca_max": hca_factor.max().item(),
             "hca_min": hca_factor.min().item(),
-            "hca_mean": hca_factor.mean().item(),
+            "hca_mean": hca_mean,
+            "hca_std": hca_std,
+            "adv_max": exps.advantage.max().item(),
+            "adv_min": exps.advantage.min().item(),
+            "adv_mean": adv_mean,
+            "adv_std": adv_std,
         })
 
         return logs

--- a/rl_credit/algos/hca_returns.py
+++ b/rl_credit/algos/hca_returns.py
@@ -23,6 +23,8 @@ class HCAReturns(BaseAlgo):
                                              alpha=rmsprop_alpha, eps=rmsprop_eps)
 
     def update_parameters(self, exps):
+        logs = {}
+
         # Compute loss
         dist, value, hca_logits = self.acmodel(exps.obs, exps.returnn)
 
@@ -31,13 +33,21 @@ class HCAReturns(BaseAlgo):
             hca_prob = torch.gather(F.softmax(hca_logits, dim=1),
                                     dim=1,
                                     index=exps.action.view(-1,1).long()).squeeze()
-            hca_factor = (1 - torch.exp(exps.log_prob) / hca_prob ) * exps.returnn
+            pi_hca_ratio = torch.exp(exps.log_prob) / hca_prob
+            hca_factor = (1 - pi_hca_ratio) * exps.returnn
+
+            logs['hca_prob_max'] = hca_prob.max().item()
+            logs['hca_prob_min'] = hca_prob.min().item()
+            logs['hca_prob_mean'] = hca_prob.mean().item()
+            logs['pi_hca_ratio_max'] = pi_hca_ratio.max().item()
+            logs['pi_hca_ratio_min'] = pi_hca_ratio.min().item()
+            logs['pi_hca_ratio_mean'] = pi_hca_ratio.mean().item()
 
         entropy = dist.entropy().mean()
 
         # policy loss using hca factor
-        policy_loss = -(dist.log_prob(exps.action) * hca_factor).mean()
-        #policy_loss = -(dist.log_prob(exps.action) * exps.advantage).mean()
+        #policy_loss = -(dist.log_prob(exps.action) * hca_factor).mean()
+        policy_loss = -(dist.log_prob(exps.action) * exps.advantage).mean()
 
         value_loss = (value - exps.returnn).pow(2).mean()
 
@@ -58,13 +68,16 @@ class HCAReturns(BaseAlgo):
 
         # Log some values
 
-        logs = {
+        logs.update({
             "entropy": entropy.item(),
             "value": value.mean().item(),
             "policy_loss": policy_loss.item(),
             "value_loss": value_loss.item(),
             "grad_norm": update_grad_norm,
-            "hca": hca_loss.item()
-        }
+            "hca_loss": hca_loss.item(),
+            "hca_max": hca_factor.max().item(),
+            "hca_min": hca_factor.min().item(),
+            "hca_mean": hca_factor.mean().item(),
+        })
 
         return logs

--- a/rl_credit/scripts/train.py
+++ b/rl_credit/scripts/train.py
@@ -212,10 +212,10 @@ while num_frames < args.frames:
 
         txt_logger_output = "U {} | F {:06} | FPS {:04.0f} | D {} | rR:μσmM {:.2f} {:.2f} {:.2f} {:.2f} | F:μσmM {:.1f} {:.1f} {} {} | H {:.3f} | V {:.3f} | pL {:.3f} | vL {:.3f} | ∇ {:.3f}"
 
-        if "hca" in logs:
+        if "hca_loss" in logs:
             txt_logger_output += " | hca {:.2f}"
             header += ["hca_loss"]
-            data += [logs["hca"]]
+            data += [logs["hca_loss"]]
         txt_logger.info(txt_logger_output.format(*data))
 
         header += ["return_" + key for key in return_per_episode.keys()]

--- a/rl_credit/scripts/train.py
+++ b/rl_credit/scripts/train.py
@@ -5,6 +5,7 @@ import torch
 import rl_credit
 import tensorboardX
 import sys
+import numpy as np
 
 import script_utils as utils
 from model import ACModel, ACModelVanilla, ACModelReturnHCA, ACModelStateHCA
@@ -241,8 +242,8 @@ while num_frames < args.frames:
 
     # Wandb (optional) logging
     if args.wandb is not None:
-        logs.pop('return_per_episode')
-        logs.pop('num_frames_per_episode')
+        logs['returns_per_episode_std'] = np.std(logs.pop('return_per_episode'))
+        logs['num_frames_per_episode_std'] = np.std(logs.pop('num_frames_per_episode'))
         logs.pop('reshaped_return_per_episode')
         for x in ('mean', 'min', 'max'):
             logs[f'return_per_episode_{x}'] = return_per_episode[x]


### PR DESCRIPTION
Add more logs for
- hca returns, e.g. correlation b/w advantage and hca, pi/hca ratio, hca factor mean, min, max
- std of returns, advantage, hca factor

example run with logging implemented in this PR:
https://app.wandb.ai/frangipane/test/runs/3fljvn11?workspace=user-frangipane
(a2c w/o memory trained over 1 million frames, still does well)