### PR TITLE
Attention

### DIFF
--- a/rl_credit/__init__.py
+++ b/rl_credit/__init__.py
@@ -1,3 +1,3 @@
-from rl_credit.algos import A2CAlgo, PPOAlgo, HCAReturns, HCAState
-from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla, ACModelReturnHCA
+from rl_credit.algos import A2CAlgo, PPOAlgo, HCAReturns, HCAState, AttentionAlgo
+from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla, ACModelReturnHCA, A2CAttention
 from rl_credit.utils import DictList

--- a/rl_credit/algos/__init__.py
+++ b/rl_credit/algos/__init__.py
@@ -2,3 +2,4 @@ from rl_credit.algos.a2c import A2CAlgo
 from rl_credit.algos.ppo import PPOAlgo
 from rl_credit.algos.hca_returns import HCAReturns
 from rl_credit.algos.hca_state import HCAState
+from rl_credit.algos.attention import AttentionAlgo

--- a/rl_credit/algos/attention.py
+++ b/rl_credit/algos/attention.py
@@ -1,0 +1,445 @@
+from abc import ABC, abstractmethod
+import torch
+
+from rl_credit.format import default_preprocess_obss
+from rl_credit.utils import DictList, ParallelEnv
+import rl_credit.script_utils as utils
+
+import numpy
+import torch.nn.functional as F
+
+from rl_credit.model import A2CAttention
+
+
+class BaseAlgo(ABC):
+    """The base class for RL algorithms."""
+
+    def __init__(self, envs, acmodel, device, num_frames_per_proc, discount, lr, gae_lambda, entropy_coef,
+                 value_loss_coef, max_grad_norm, recurrence, preprocess_obss, reshape_reward):
+        """
+        Initializes a `BaseAlgo` instance.
+
+        Parameters:
+        ----------
+        envs : list
+            a list of environments that will be run in parallel
+        acmodel : torch.Module
+            the model
+        num_frames_per_proc : int
+            the number of frames collected by every process for an update
+        discount : float
+            the discount for future rewards
+        lr : float
+            the learning rate for optimizers
+        gae_lambda : float
+            the lambda coefficient in the GAE formula
+            ([Schulman et al., 2015](https://arxiv.org/abs/1506.02438))
+        entropy_coef : float
+            the weight of the entropy cost in the final objective
+        value_loss_coef : float
+            the weight of the value loss in the final objective
+        max_grad_norm : float
+            gradient will be clipped to be at most this value
+        recurrence : int
+            the number of steps the gradient is propagated back in time
+        preprocess_obss : function
+            a function that takes observations returned by the environment
+            and converts them into the format that the model can handle
+        reshape_reward : function
+            a function that shapes the reward, takes an
+            (observation, action, reward, done) tuple as an input
+        """
+
+        # Store parameters
+
+        self.env = ParallelEnv(envs)
+        self.acmodel = acmodel
+        self.device = device
+        self.num_frames_per_proc = num_frames_per_proc
+        self.discount = discount
+        self.lr = lr
+        self.gae_lambda = gae_lambda
+        self.entropy_coef = entropy_coef
+        self.value_loss_coef = value_loss_coef
+        self.max_grad_norm = max_grad_norm
+        self.recurrence = recurrence
+        self.preprocess_obss = preprocess_obss or default_preprocess_obss
+        self.reshape_reward = reshape_reward
+
+        # Control parameters
+
+        assert self.acmodel.recurrent or self.recurrence == 1
+        assert self.num_frames_per_proc % self.recurrence == 0
+
+        # Configure acmodel
+
+        self.acmodel.to(self.device)
+        self.acmodel.train()
+
+        # Store helpers values
+
+        self.num_procs = len(envs)
+        self.num_frames = self.num_frames_per_proc * self.num_procs
+
+        # Initialize experience values
+
+        shape = (self.num_frames_per_proc, self.num_procs)
+
+        self.obs = self.env.reset()
+        self.obss = [None]*(shape[0])
+        if self.acmodel.recurrent:
+            self.memory = torch.zeros(shape[1], self.acmodel.memory_size, device=self.device)
+            self.memories = torch.zeros(*shape, self.acmodel.memory_size, device=self.device)
+        self.mask = torch.ones(shape[1], device=self.device)
+        self.masks = torch.zeros(*shape, device=self.device)
+        self.actions = torch.zeros(*shape, device=self.device, dtype=torch.int)
+        self.values = torch.zeros(*shape, device=self.device)
+        self.rewards = torch.zeros(*shape, device=self.device)
+        self.advantages = torch.zeros(*shape, device=self.device)
+        self.log_probs = torch.zeros(*shape, device=self.device)
+
+        # Initialize log values
+
+        self.log_episode_return = torch.zeros(self.num_procs, device=self.device)
+        self.log_episode_reshaped_return = torch.zeros(self.num_procs, device=self.device)
+        self.log_episode_num_frames = torch.zeros(self.num_procs, device=self.device)
+
+        self.log_done_counter = 0
+        self.log_return = [0] * self.num_procs
+        self.log_reshaped_return = [0] * self.num_procs
+        self.log_num_frames = [0] * self.num_procs
+
+    def collect_experiences(self):
+        """Collects rollouts and computes advantages.
+
+        Runs several environments concurrently. The next actions are computed
+        in a batch mode for all environments at the same time. The rollouts
+        and advantages from all environments are concatenated together.
+
+        Returns
+        -------
+        exps : DictList
+            Contains actions, rewards, advantages etc as attributes.
+            Each attribute, e.g. `exps.reward` has a shape
+            (self.num_frames_per_proc * num_envs, ...). k-th block
+            of consecutive `self.num_frames_per_proc` frames contains
+            data obtained from the k-th environment. Be careful not to mix
+            data from different environments!
+        logs : dict
+            Useful stats about the training process, including the average
+            reward, policy loss, value loss, etc.
+        """
+
+        for i in range(self.num_frames_per_proc):
+            # Do one agent-environment interaction
+
+            preprocessed_obs = self.preprocess_obss(self.obs, device=self.device)
+            # preprocessed_obs shape: [num_procs, h, w, c]
+            # add extra dim for ep len so shape -> [num_procs, 1, h, w, c]
+            preprocessed_obs = torch.unsqueeze(preprocessed_obs, dim=1)
+
+            with torch.no_grad():
+                if self.acmodel.recurrent:
+                    dist, value, memory = self.acmodel(preprocessed_obs, self.memory * self.mask.unsqueeze(1))
+                else:
+                    dist, _ = self.acmodel(preprocessed_obs)
+            action = dist.sample()
+
+            obs, reward, done, _ = self.env.step(action.cpu().numpy())
+            # Update experiences values
+
+            self.obss[i] = self.obs
+            self.obs = obs
+            if self.acmodel.recurrent:
+                self.memories[i] = self.memory
+                self.memory = memory
+            self.masks[i] = self.mask
+            self.mask = 1 - torch.tensor(done, device=self.device, dtype=torch.float)
+            self.actions[i] = action
+            #self.values[i] = value
+            if self.reshape_reward is not None:
+                self.rewards[i] = torch.tensor([
+                    self.reshape_reward(obs_, action_, reward_, done_)
+                    for obs_, action_, reward_, done_ in zip(obs, action, reward, done)
+                ], device=self.device)
+            else:
+                self.rewards[i] = torch.tensor(reward, device=self.device)
+            self.log_probs[i] = dist.log_prob(action)
+
+            # Update log values
+
+            self.log_episode_return += torch.tensor(reward, device=self.device, dtype=torch.float)
+            self.log_episode_reshaped_return += self.rewards[i]
+            self.log_episode_num_frames += torch.ones(self.num_procs, device=self.device)
+
+            for i, done_ in enumerate(done):
+                if done_:
+                    self.log_done_counter += 1
+                    self.log_return.append(self.log_episode_return[i].item())
+                    self.log_reshaped_return.append(self.log_episode_reshaped_return[i].item())
+                    self.log_num_frames.append(self.log_episode_num_frames[i].item())
+
+            self.log_episode_return *= self.mask
+            self.log_episode_reshaped_return *= self.mask
+            self.log_episode_num_frames *= self.mask
+
+        # Add advantage and return to experiences
+
+        preprocessed_obs = self.preprocess_obss(self.obs, device=self.device)
+        preprocessed_obs = torch.unsqueeze(preprocessed_obs, dim=1)
+
+        # bootstrapped final value for unfinished trajectories cut off by end
+        # of epoch (=num frames per proc)
+        with torch.no_grad():
+            if self.acmodel.recurrent:
+                _, next_value, _ = self.acmodel(preprocessed_obs, self.memory * self.mask.unsqueeze(1))
+            else:
+                _, next_value = self.acmodel(preprocessed_obs)
+
+        for i in reversed(range(self.num_frames_per_proc)):
+            next_mask = self.masks[i+1] if i < self.num_frames_per_proc - 1 else self.mask
+            next_value = self.values[i+1] if i < self.num_frames_per_proc - 1 else next_value
+            next_advantage = self.advantages[i+1] if i < self.num_frames_per_proc - 1 else 0
+
+            delta = self.rewards[i] + self.discount * next_value * next_mask - self.values[i]
+            self.advantages[i] = delta + self.discount * self.gae_lambda * next_advantage * next_mask
+
+        # Define experiences:
+        #   the whole experience is the concatenation of the experience
+        #   of each process.
+        # In comments below:
+        #   - T is self.num_frames_per_proc,
+        #   - P is self.num_procs,
+        #   - D is the dimensionality.
+
+        # Reshape obss into tensor of (batch size=num_procs, seq len=frames per proc, *(image_dim))
+        self.obss_mat = [None]*(self.num_procs)
+        for i in range(self.num_procs):
+            self.obss_mat[i] = self.preprocess_obss([self.obss[j][i]
+                                                     for j in range(self.num_frames_per_proc)])
+        self.obss_mat = torch.cat(self.obss_mat).view(self.num_procs, *self.obss_mat[0].shape)
+        
+        exps = DictList()
+        # exps.obs = [self.obss[i][j]
+        #             for j in range(self.num_procs)
+        #             for i in range(self.num_frames_per_proc)]
+        if self.acmodel.recurrent:
+            # T x P x D -> P x T x D -> (P * T) x D
+            exps.memory = self.memories.transpose(0, 1).reshape(-1, *self.memories.shape[2:])
+            # T x P -> P x T -> (P * T) x 1
+            exps.mask = self.masks.transpose(0, 1).reshape(-1).unsqueeze(1)
+        # for all tensors below, T x P -> P x T -> P * T
+        exps.action = self.actions.transpose(0, 1).reshape(-1)
+        exps.value = self.values.transpose(0, 1).reshape(-1)
+        exps.reward = self.rewards.transpose(0, 1).reshape(-1)
+        exps.advantage = self.advantages.transpose(0, 1).reshape(-1)
+
+        # TODO: calculate returnn later (need value fxn for batch of obs in episode)
+        exps.returnn = exps.value + exps.advantage
+        # normalize the advantage
+        exps.advantage = (exps.advantage - exps.advantage.mean())/exps.advantage.std()
+        exps.log_prob = self.log_probs.transpose(0, 1).reshape(-1)
+
+        # Preprocess experiences
+
+        #exps.obs = self.preprocess_obss(exps.obs, device=self.device)
+
+        # Log some values
+
+        keep = max(self.log_done_counter, self.num_procs)
+
+        logs = {
+            "return_per_episode": self.log_return[-keep:],
+            "reshaped_return_per_episode": self.log_reshaped_return[-keep:],
+            "num_frames_per_episode": self.log_num_frames[-keep:],
+            "num_frames": self.num_frames
+        }
+
+        self.log_done_counter = 0
+        self.log_return = self.log_return[-self.num_procs:]
+        self.log_reshaped_return = self.log_reshaped_return[-self.num_procs:]
+        self.log_num_frames = self.log_num_frames[-self.num_procs:]
+
+        #return exps, logs
+        return self.obss_mat, exps, logs
+
+    @abstractmethod
+    def update_parameters(self):
+        pass
+
+
+class AttentionAlgo(BaseAlgo):
+    """The Advantage Actor-Critic algorithm."""
+
+    def __init__(self, envs, acmodel, device=None, num_frames_per_proc=None, discount=0.99, lr=0.01, gae_lambda=0.95,
+                 entropy_coef=0.01, value_loss_coef=0.5, max_grad_norm=0.5, recurrence=4,
+                 rmsprop_alpha=0.99, rmsprop_eps=1e-8, preprocess_obss=None, reshape_reward=None):
+        num_frames_per_proc = num_frames_per_proc or 8
+
+        super().__init__(envs, acmodel, device, num_frames_per_proc, discount, lr, gae_lambda, entropy_coef,
+                         value_loss_coef, max_grad_norm, recurrence, preprocess_obss, reshape_reward)
+
+        self.optimizer = torch.optim.RMSprop(self.acmodel.parameters(), lr,
+                                             alpha=rmsprop_alpha, eps=rmsprop_eps)
+
+    def update_parameters(self, obss, exps):
+        # Compute starting indexes
+
+        inds = self._get_starting_indexes()
+
+        # Initialize update values
+
+        update_entropy = 0
+        update_value = 0
+        update_policy_loss = 0
+        update_value_loss = 0
+        update_loss = 0
+
+        # Initialize memory
+
+        if self.acmodel.recurrent:
+            memory = exps.memory[inds]
+
+        for i in range(self.recurrence):
+            # Create a sub-batch of experience
+
+            sb = exps[inds + i]
+
+            # Compute loss
+
+            if self.acmodel.recurrent:
+                dist, value, memory = self.acmodel(sb.obs, memory * sb.mask)
+            else:
+                #dist, value = self.acmodel(sb.obs)
+                dist, value = self.acmodel(obss)
+
+            entropy = dist.entropy().mean()
+
+            policy_loss = -(dist.log_prob(sb.action) * sb.advantage).mean()
+
+            value_loss = (value - sb.returnn).pow(2).mean()
+
+            loss = policy_loss - self.entropy_coef * entropy + self.value_loss_coef * value_loss
+
+            # Update batch values
+
+            update_entropy += entropy.item()
+            update_value += value.mean().item()
+            update_policy_loss += policy_loss.item()
+            update_value_loss += value_loss.item()
+            update_loss += loss
+
+        # Update update values
+
+        update_entropy /= self.recurrence
+        update_value /= self.recurrence
+        update_policy_loss /= self.recurrence
+        update_value_loss /= self.recurrence
+        update_loss /= self.recurrence
+
+        # Update actor-critic
+
+        self.optimizer.zero_grad()
+        update_loss.backward()
+        update_grad_norm = sum(p.grad.data.norm(2) ** 2 for p in self.acmodel.parameters()) ** 0.5
+        torch.nn.utils.clip_grad_norm_(self.acmodel.parameters(), self.max_grad_norm)
+        self.optimizer.step()
+
+        # Log some values
+
+        with torch.no_grad():
+            # evaluate KL divergence b/w old and new policy
+            # policy under newly updated model
+            if self.acmodel.recurrent:
+                dist, _, _ = self.acmodel(exps.obs, exps.memory * exps.mask)
+            else:
+                dist, _ = self.acmodel(obss)
+
+            approx_kl = (exps.log_prob - dist.log_prob(exps.action)).mean().item()
+            adv_mean = exps.advantage.mean().item()
+            adv_max = exps.advantage.max().item()
+            adv_min = exps.advantage.min().item()
+            adv_std = exps.advantage.std().item()
+
+            # standard deviation of values
+            value_std = value.std().item()
+
+        logs = {
+            "entropy": update_entropy,
+            "value": update_value,
+            "value_std": value_std,
+            "policy_loss": update_policy_loss,
+            "value_loss": update_value_loss,
+            "grad_norm": update_grad_norm,
+            "adv_max": adv_max,
+            "adv_min": adv_min,
+            "adv_mean": adv_mean,
+            "adv_std": adv_std,
+            "kl": approx_kl,
+        }
+
+        return logs
+
+    def _get_starting_indexes(self):
+        """Gives the indexes of the observations given to the model and the
+        experiences used to compute the loss at first.
+
+        The indexes are the integers from 0 to `self.num_frames` with a step of
+        `self.recurrence`. If the model is not recurrent, they are all the
+        integers from 0 to `self.num_frames`.
+
+        Returns
+        -------
+        starting_indexes : list of int
+            the indexes of the experiences to be used at first
+        """
+
+        starting_indexes = numpy.arange(0, self.num_frames, self.recurrence)
+        return starting_indexes
+
+
+def get_obss_preprocessor(obs_space):
+    import gym
+    # Check if it is a MiniGrid observation space
+    if isinstance(obs_space, gym.spaces.Dict) and list(obs_space.spaces.keys()) == ["image"]:
+        obs_space = obs_space.spaces["image"].shape
+
+        def preprocess_obss(obss, device=None):
+            images = numpy.array([obs["image"] for obs in obss])
+            return torch.tensor(images, device=device, dtype=torch.float)
+    else:
+        raise ValueError("Unknown observation space: " + str(obs_space))
+
+    return obs_space, preprocess_obss
+
+
+if __name__ == '__main__':
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    num_procs = 4
+    seed = 0
+
+    envs = []
+    for i in range(num_procs):
+        envs.append(utils.make_env('MiniGrid-KeyGoal-6x6-v0', seed + 10000 * i))
+
+    obs_space, preprocess_obss = get_obss_preprocessor(envs[0].observation_space)
+    acmodel = A2CAttention(obs_space, envs[0].action_space,)
+
+    algo_args=dict(device=device,
+                   num_frames_per_proc=128,
+                   discount=1.,
+                   lr=0.001,
+                   gae_lambda=1.,
+                   entropy_coef=0.,
+                   value_loss_coef=0.5,
+                   max_grad_norm=0.5,
+                   recurrence=1,
+                   rmsprop_alpha=0.99,
+                   rmsprop_eps=1e-8,
+                   preprocess_obss=preprocess_obss)
+    algo = AttentionAlgo(envs, acmodel, **algo_args)
+
+    total_frames = 0
+    obss, exps, logs = algo.collect_experiences()
+    algo.update_parameters(obss, exps)
+    total_frames += logs['num_frames']

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -317,100 +317,6 @@ class ACModelStateHCA(ACModelVanilla):
         return dist, value
 
 
-# No memory, no text
-# class A2CAttention(nn.Module, BaseModel):
-#     def __init__(self, obs_space, action_space, d_key=5):
-#         """
-#         d_key : int, dimension of image embedding projected
-#            to query (and key) for attention
-#         """
-#         super().__init__()
-
-#         # Define image embedding
-#         self.image_conv = nn.Sequential(
-#             nn.Conv2d(3, 16, (2, 2)),
-#             nn.ReLU(),
-#             nn.MaxPool2d((2, 2)),
-#             nn.Conv2d(16, 32, (2, 2)),
-#             nn.ReLU(),
-#             nn.Conv2d(32, 64, (2, 2)),
-#             nn.ReLU()
-#         )
-#         n = obs_space[0]
-#         m = obs_space[1]
-#         self.image_embedding_size = ((n-1)//2-2)*((m-1)//2-2)*64
-
-#         # Define actor's model
-#         self.actor = nn.Sequential(
-#             nn.Linear(self.image_embedding_size, 64),
-#             nn.Tanh(),
-#             nn.Linear(64, action_space.n)
-#         )
-
-#         # Define self-attention vector for inputting into critic
-#         self.d_key = d_key
-#         self.Wq = nn.Linear(self.image_embedding_size, d_key, bias=False)
-#         self.Wk = nn.Linear(self.image_embedding_size, d_key, bias=False)
-#         self.Wv = nn.Linear(self.image_embedding_size, d_key, bias=False)
-
-#         # Define critic's model
-#         self.critic = nn.Sequential(
-#             nn.Linear(self.d_key, 32),
-#             nn.Tanh(),
-#             nn.Linear(32, 1)
-#         )
-
-#         # Initialize parameters correctly
-#         self.apply(init_params)
-
-#     def forward(self, obs, mask_future=True):
-#         skip_critic = False
-
-#         if obs.dim() == 4:
-#             # agent step through episode, wait to calculate value only
-#             # at the end of the episode
-#             skip_critic = True
-#             # each batch contains just 1 image, not a sequence of images
-#             x = obs.transpose(1, 3).transpose(2, 3)
-#             x = self.image_conv(x)
-#             x = x.reshape(x.shape[0], -1)
-
-#             embedding = x  # dim 2
-
-#             # policy
-#             x = self.actor(embedding)
-#             dist = Categorical(logits=F.log_softmax(x, dim=1))
-#             return dist
-
-#         assert obs.image.dim() == 5
-#         # TODO: handle CNN when batch is a sequence of images
-#         # policy also has to be able to handle the xtra dim
-#         raise
-#         embedding = x  # dim 3
-#         batch_size, ep_len, img_embed_size = embedding.shape
-
-#         # ==== attention before critic ====
-#         queries = self.Wq(embedding) / (self.d_key ** (1/4))
-#         keys = self.Wk(embedding) / (self.d_key ** (1/4))
-#         values = self.Wv(embedding)
-
-#         scores = torch.bmm(queries, keys.transpose(1, 2))
-
-#         # Filter out self attention to future values
-#         if mask_future is True:
-#             scores_mask = torch.ones([ep_len, ep_len]).tril()
-#             scores.masked_fill_(scores_mask == 0, float('-inf'))
-        
-#         scores = F.softmax(scores, axis=2)    # shape = (batch_size, ep_len, ep_len)
-#         attn_out = torch.bmm(scores, values)  # shape = (batch_size, ep_len, d_key)
-
-#         # critic
-#         x = self.critic(attn_out)
-#         value = x.squeeze(1)
-
-#         return dist, value, scores
-
-
 class A2CAttention(nn.Module, BaseModel):
     def __init__(self, obs_space, action_space, d_key=5):
         """
@@ -440,18 +346,29 @@ class A2CAttention(nn.Module, BaseModel):
             nn.Linear(64, action_space.n)
         )
 
+        # Define self-attention vector for input into critic
+        self.d_key = d_key
+        self.Wq = nn.Linear(self.image_embedding_size, d_key, bias=False)
+        self.Wk = nn.Linear(self.image_embedding_size, d_key, bias=False)
+        self.Wv = nn.Linear(self.image_embedding_size, d_key, bias=False)
+
         # Define critic's model
         self.critic = nn.Sequential(
-            nn.Linear(self.image_embedding_size, 64),
+            nn.Linear(self.d_key, 32),
             nn.Tanh(),
-            nn.Linear(64, 1)
+            nn.Linear(32, 1)
         )
 
         # Initialize parameters correctly
         self.apply(init_params)
 
     def forward(self, obs, mask_future=True):
-        assert obs.dim() == 5
+        # expect obs to be dim 5, but for compatibility with other scripts
+        # that don't have an extra dimension for sequence length, add
+        # an extra dimension if obs dim is 4
+        if obs.dim() == 4:
+            obs = obs.unsqueeze(1)
+
         batch_size, ep_len, h, w, c = obs.shape
 
         if ep_len == 1:
@@ -463,14 +380,35 @@ class A2CAttention(nn.Module, BaseModel):
         x = self.image_conv(x)
         x = x.reshape(x.shape[0], -1)
 
-        embedding = x  # dim 2: (batch_size, embedding size)
+        embedding = x  # dim 2: (batch_size * ep_len, embedding size)
 
         # policy
         x = self.actor(embedding)
         dist = Categorical(logits=F.log_softmax(x, dim=1))
 
-        # critic
-        x = self.critic(embedding)
+        if ep_len == 1:
+            # forward pass is just a single step in to figure out action to take
+            # in env, so skip value evaluation
+            # TODO: allow value prediction for single obs / use context vector
+            # use 0 as placeholder temporary
+            return dist, torch.tensor([0.])
+
+        # ==== attention before critic ====
+        queries = self.Wq(embedding).view(batch_size, ep_len, self.d_key) / (self.d_key ** (1/4))
+        keys = self.Wk(embedding).view(batch_size, ep_len, self.d_key) / (self.d_key ** (1/4))
+        values = self.Wv(embedding).view(batch_size, ep_len, self.d_key)
+
+        scores = torch.bmm(queries, keys.transpose(1, 2))
+
+        # Filter out self attention to future values
+        if mask_future is True:
+            scores_mask = torch.ones([ep_len, ep_len]).tril()
+            scores.masked_fill_(scores_mask == 0, float('-inf'))
+
+        scores = F.softmax(scores, dim=2)    # shape = (batch_size, ep_len, ep_len)
+        attn_out = torch.bmm(scores, values)  # shape = (batch_size, ep_len, d_key)
+
+        x = self.critic(attn_out.view(batch_size * ep_len, self.d_key))
         value = x.squeeze(1)
 
         return dist, value

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -315,3 +315,162 @@ class ACModelStateHCA(ACModelVanilla):
             return dist, value, reward
 
         return dist, value
+
+
+# No memory, no text
+# class A2CAttention(nn.Module, BaseModel):
+#     def __init__(self, obs_space, action_space, d_key=5):
+#         """
+#         d_key : int, dimension of image embedding projected
+#            to query (and key) for attention
+#         """
+#         super().__init__()
+
+#         # Define image embedding
+#         self.image_conv = nn.Sequential(
+#             nn.Conv2d(3, 16, (2, 2)),
+#             nn.ReLU(),
+#             nn.MaxPool2d((2, 2)),
+#             nn.Conv2d(16, 32, (2, 2)),
+#             nn.ReLU(),
+#             nn.Conv2d(32, 64, (2, 2)),
+#             nn.ReLU()
+#         )
+#         n = obs_space[0]
+#         m = obs_space[1]
+#         self.image_embedding_size = ((n-1)//2-2)*((m-1)//2-2)*64
+
+#         # Define actor's model
+#         self.actor = nn.Sequential(
+#             nn.Linear(self.image_embedding_size, 64),
+#             nn.Tanh(),
+#             nn.Linear(64, action_space.n)
+#         )
+
+#         # Define self-attention vector for inputting into critic
+#         self.d_key = d_key
+#         self.Wq = nn.Linear(self.image_embedding_size, d_key, bias=False)
+#         self.Wk = nn.Linear(self.image_embedding_size, d_key, bias=False)
+#         self.Wv = nn.Linear(self.image_embedding_size, d_key, bias=False)
+
+#         # Define critic's model
+#         self.critic = nn.Sequential(
+#             nn.Linear(self.d_key, 32),
+#             nn.Tanh(),
+#             nn.Linear(32, 1)
+#         )
+
+#         # Initialize parameters correctly
+#         self.apply(init_params)
+
+#     def forward(self, obs, mask_future=True):
+#         skip_critic = False
+
+#         if obs.dim() == 4:
+#             # agent step through episode, wait to calculate value only
+#             # at the end of the episode
+#             skip_critic = True
+#             # each batch contains just 1 image, not a sequence of images
+#             x = obs.transpose(1, 3).transpose(2, 3)
+#             x = self.image_conv(x)
+#             x = x.reshape(x.shape[0], -1)
+
+#             embedding = x  # dim 2
+
+#             # policy
+#             x = self.actor(embedding)
+#             dist = Categorical(logits=F.log_softmax(x, dim=1))
+#             return dist
+
+#         assert obs.image.dim() == 5
+#         # TODO: handle CNN when batch is a sequence of images
+#         # policy also has to be able to handle the xtra dim
+#         raise
+#         embedding = x  # dim 3
+#         batch_size, ep_len, img_embed_size = embedding.shape
+
+#         # ==== attention before critic ====
+#         queries = self.Wq(embedding) / (self.d_key ** (1/4))
+#         keys = self.Wk(embedding) / (self.d_key ** (1/4))
+#         values = self.Wv(embedding)
+
+#         scores = torch.bmm(queries, keys.transpose(1, 2))
+
+#         # Filter out self attention to future values
+#         if mask_future is True:
+#             scores_mask = torch.ones([ep_len, ep_len]).tril()
+#             scores.masked_fill_(scores_mask == 0, float('-inf'))
+        
+#         scores = F.softmax(scores, axis=2)    # shape = (batch_size, ep_len, ep_len)
+#         attn_out = torch.bmm(scores, values)  # shape = (batch_size, ep_len, d_key)
+
+#         # critic
+#         x = self.critic(attn_out)
+#         value = x.squeeze(1)
+
+#         return dist, value, scores
+
+
+class A2CAttention(nn.Module, BaseModel):
+    def __init__(self, obs_space, action_space, d_key=5):
+        """
+        d_key : int, dimension of image embedding projected
+           to query (and key) for attention
+        """
+        super().__init__()
+
+        # Define image embedding
+        self.image_conv = nn.Sequential(
+            nn.Conv2d(3, 16, (2, 2)),
+            nn.ReLU(),
+            nn.MaxPool2d((2, 2)),
+            nn.Conv2d(16, 32, (2, 2)),
+            nn.ReLU(),
+            nn.Conv2d(32, 64, (2, 2)),
+            nn.ReLU()
+        )
+        n = obs_space[0]
+        m = obs_space[1]
+        self.image_embedding_size = ((n-1)//2-2)*((m-1)//2-2)*64
+
+        # Define actor's model
+        self.actor = nn.Sequential(
+            nn.Linear(self.image_embedding_size, 64),
+            nn.Tanh(),
+            nn.Linear(64, action_space.n)
+        )
+
+        # Define critic's model
+        self.critic = nn.Sequential(
+            nn.Linear(self.image_embedding_size, 64),
+            nn.Tanh(),
+            nn.Linear(64, 1)
+        )
+
+        # Initialize parameters correctly
+        self.apply(init_params)
+
+    def forward(self, obs, mask_future=True):
+        assert obs.dim() == 5
+        batch_size, ep_len, h, w, c = obs.shape
+
+        if ep_len == 1:
+            obs = torch.squeeze(obs, dim=1)
+        elif ep_len > 1:
+            obs = obs.reshape(batch_size * ep_len, h, w, c)
+
+        x = obs.transpose(1, 3).transpose(2, 3)
+        x = self.image_conv(x)
+        x = x.reshape(x.shape[0], -1)
+
+        embedding = x  # dim 2: (batch_size, embedding size)
+
+        # policy
+        x = self.actor(embedding)
+        dist = Categorical(logits=F.log_softmax(x, dim=1))
+
+        # critic
+        x = self.critic(embedding)
+        value = x.squeeze(1)
+
+        return dist, value

--- a/rl_credit/script_utils/agent.py
+++ b/rl_credit/script_utils/agent.py
@@ -1,7 +1,7 @@
 import torch
 
-import script_utils as utils
-from model import ACModel, ACModelReturnHCA, ACModelStateHCA
+import rl_credit.script_utils as utils
+from rl_credit.model import ACModel, ACModelReturnHCA, ACModelStateHCA, A2CAttention
 
 
 class Agent:
@@ -13,12 +13,18 @@ class Agent:
 
     def __init__(self, obs_space, action_space, model_dir,
                  device=None, argmax=False, num_envs=1, use_memory=False, use_text=False,
-                 hca_returns=False, hca_state=False):
-        obs_space, self.preprocess_obss = utils.get_obss_preprocessor(obs_space)
+                 hca_returns=False, hca_state=False, attention=False, d_key=5):
+        if attention is True:
+            from rl_credit.algos.attention import get_obss_preprocessor
+            obs_space, self.preprocess_obss = get_obss_preprocessor(obs_space)
+        else:
+            obs_space, self.preprocess_obss = utils.get_obss_preprocessor(obs_space)
         if hca_returns:
             self.acmodel = ACModelReturnHCA(obs_space, action_space)
         elif hca_state:
             self.acmodel = ACModelStateHCA(obs_space, action_space)
+        elif attention:
+            self.acmodel = A2CAttention(obs_space, action_space, d_key)
         else:
             self.acmodel = ACModel(obs_space, action_space, use_memory=use_memory, use_text=use_text)
         self.device = device

--- a/rl_credit/script_utils/format.py
+++ b/rl_credit/script_utils/format.py
@@ -6,7 +6,7 @@ import torch
 import rl_credit
 import gym
 
-import script_utils as utils
+import rl_credit.script_utils as utils
 
 
 def get_obss_preprocessor(obs_space):

--- a/rl_credit/script_utils/storage.py
+++ b/rl_credit/script_utils/storage.py
@@ -4,7 +4,7 @@ import torch
 import logging
 import sys
 
-import script_utils as utils
+import rl_credit.script_utils as utils
 
 
 def create_folders_if_necessary(path):

--- a/rl_credit/scripts/visualize.py
+++ b/rl_credit/scripts/visualize.py
@@ -33,6 +33,10 @@ parser.add_argument("--hcareturns", action="store_true", default=False,
                     help="use HCA returns model")
 parser.add_argument("--hcastate", action="store_true", default=False,
                     help="use HCA state model")
+parser.add_argument("--attention", action="store_true", default=False,
+                    help="use A2CAttention model")
+parser.add_argument("--d-key", type=int, default=5,
+                    help="rank of attention matrix (default: 5)")
 
 args = parser.parse_args()
 
@@ -57,7 +61,8 @@ print("Environment loaded\n")
 model_dir = utils.get_model_dir(args.model)
 agent = utils.Agent(env.observation_space, env.action_space, model_dir,
                     device=device, argmax=args.argmax, use_memory=args.memory, use_text=args.text,
-                    hca_returns=args.hcareturns, hca_state=args.hcastate)
+                    hca_returns=args.hcareturns, hca_state=args.hcastate, attention=args.attention,
+                    d_key=args.d_key)
 print("Agent loaded\n")
 
 # Run the agent


### PR DESCRIPTION
First pass: add attention to critic head of an A2C model.  Example [wandb run](https://app.wandb.ai/frangipane/attention/runs/25ky5ca5?workspace=user-frangipane) achieves similar mean returns as A2C, but training is more stable.  Value loss is curiously large in comparison to A2C.  Also, by 1 mill frames, attention model still has episodes where agent ignores key, but A2C does not.  Mean frames per episode seem much lower for attention agent than a2c agent, but this is not obvious as a big different in returns because reward for reaching goal is 
`1 - 0.9 * (self.step_count / self.max_steps)` from https://github.com/frangipane/gym-minigrid/blob/master/gym_minigrid/minigrid.py#L873.  So penalty for taking an extra 100 steps when `self.max_steps = 360` is only less 0.25 points.

Notes:
- Implementation doesn't support using history/context in real time for policy (TODO: think about how to do this, or support LSTM)
- attention is implemented jankily so that it's possible to pay attention to an observation from a totally different sequence for the value prediction.  Not entirely clear how to implement the batch training for different sequence lengths yet, but this is high priority.
- model should return attention scores to be potentially used by the algo.