### PR TITLE
Actually calculate bootstrapped last value

### DIFF
--- a/rl_credit/__init__.py
+++ b/rl_credit/__init__.py
@@ -1,3 +1,3 @@
 from rl_credit.algos import A2CAlgo, PPOAlgo, HCAReturns, HCAState, AttentionAlgo
-from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla, ACModelReturnHCA, A2CAttention
+from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla, ACModelReturnHCA, ACAttention
 from rl_credit.utils import DictList


### PR DESCRIPTION
Bootstrapped values were arbitrarily set to 0 for end-of-buffer estimated returns originally out of convenience, since values now require context for calculation, and model/algo doesn't yet store context buffer for stepping.  Update so `next_value` bootstrapping actually uses previous context.

result: value loss decreases as expected, but performance (mean returns) also worsens (see wandb [report](https://app.wandb.ai/frangipane/attention/reports/Attention-value-loss-debug--VmlldzoxMTk0NzE))