### PR TITLE
A2cq

### DIFF
--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -1,3 +1,10 @@
+"""
+Uses AttentionQ model: A2C with a 3rd Qvalue head using an attention layer that takes
+image embedding and one hot encoded action as input.
+
+Qvalue loss is included in total loss, but Qvalues do not directly modify advantage calculated
+from the critic.
+"""
 import os
 from abc import ABC, abstractmethod
 
@@ -10,12 +17,13 @@ import torch.nn.functional as F
 from rl_credit.utils import DictList, ParallelEnv
 import rl_credit.script_utils as utils
 
-from rl_credit.algos.attention import BaseAlgo, get_obss_preprocessor
+from rl_credit.algos.base import BaseAlgo
+from rl_credit.algos.attention import get_obss_preprocessor
 from rl_credit.model import AttentionQ
 
 
 class AttentionQAlgo(BaseAlgo):
-    """The Advantage Actor-Critic algorithm with attention used in the Critic."""
+    """The Advantage Actor-Critic algorithm with a third attention Q value head"""
 
     def __init__(self, envs, acmodel, device=None, num_frames_per_proc=None, discount=0.99, lr=0.01, gae_lambda=0.95,
                  entropy_coef=0.01, value_loss_coef=0.5, max_grad_norm=0.5, recurrence=4,

--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -1,9 +1,7 @@
 """
-Uses AttentionQ model: A2C with a 3rd Qvalue head using an attention layer that takes
-image embedding and one hot encoded action as input.
-
-Qvalue loss is included in total loss, but Qvalues do not directly modify advantage calculated
-from the critic.
+Vanilla A2C (with or without LSTM memory) with a separate Qvalue model using an attention
+layer that takes in image embedding or hidden state from the A2C model, as well as a
+ one hot encoded action as input.
 """
 import os
 from abc import ABC, abstractmethod
@@ -18,24 +16,33 @@ from rl_credit.utils import DictList, ParallelEnv
 import rl_credit.script_utils as utils
 
 from rl_credit.algos.base import BaseAlgo
-from rl_credit.algos.attention import get_obss_preprocessor
-from rl_credit.model import AttentionQ
+from rl_credit.model import QAttentionModel
 
 
 class AttentionQAlgo(BaseAlgo):
-    """The Advantage Actor-Critic algorithm with a third attention Q value head"""
+    """The Advantage Actor-Critic algorithm with a separate attention Qvalue model"""
 
     def __init__(self, envs, acmodel, device=None, num_frames_per_proc=None, discount=0.99, lr=0.01, gae_lambda=0.95,
                  entropy_coef=0.01, value_loss_coef=0.5, max_grad_norm=0.5, recurrence=4,
                  rmsprop_alpha=0.99, rmsprop_eps=1e-8, preprocess_obss=None, reshape_reward=None,
-                 wandb_dir=None):
+                 wandb_dir=None, d_key=30):
         num_frames_per_proc = num_frames_per_proc or 8
 
         super().__init__(envs, acmodel, device, num_frames_per_proc, discount, lr, gae_lambda, entropy_coef,
-                         value_loss_coef, max_grad_norm, recurrence, preprocess_obss, reshape_reward)
+                         value_loss_coef, max_grad_norm, recurrence, preprocess_obss, reshape_reward,
+                         store_embeddings=True)
+
+        # TODO: allow user to pass in QAttentionModel instance and kwargs, e.g. in training script
+        self.qmodel = QAttentionModel(embedding_size=self.acmodel.semi_memory_size,
+                                      action_size=7,
+                                      d_key=d_key)
 
         self.optimizer = torch.optim.RMSprop(self.acmodel.parameters(), lr,
                                              alpha=rmsprop_alpha, eps=rmsprop_eps)
+
+        # TODO: allow a separate learning rate for qvalue
+        self.qvalue_optimizer = torch.optim.RMSprop(self.qmodel.parameters(), lr,
+                                                    alpha=rmsprop_alpha, eps=rmsprop_eps)
 
         self._update_number = 0  # convenience, for debugging, occasional saves
         self.wandb_dir = wandb_dir
@@ -60,107 +67,18 @@ class AttentionQAlgo(BaseAlgo):
             Useful stats about the training process, including the average
             reward, policy loss, value loss, etc.
         """
-        for i in range(self.num_frames_per_proc):
-            # Do one agent-environment interaction
+        # Step through env using A2C
+        exps, logs = super().collect_experiences()
 
-            preprocessed_obs = self.preprocess_obss(self.obs, device=self.device)
-            # preprocessed_obs shape: [num_procs, h, w, c]
-            # add extra dim for ep len so shape -> [num_procs, 1, h, w, c]
-            preprocessed_obs = torch.unsqueeze(preprocessed_obs, dim=1)
+        # ===== Calculate Qvalues using attention (context from experiences) =====
 
-            with torch.no_grad():
-                dist, value = self.acmodel(preprocessed_obs)
-            action = dist.sample()
-
-            next_obs, reward, done, _ = self.env.step(action.cpu().numpy())
-
-            # Update experiences values
-            self.obss[i] = self.obs
-            self.values[i] = value
-            self.actions[i] = action
-            self.masks[i] = self.mask
-            self.mask = 1 - torch.tensor(done, device=self.device, dtype=torch.float)
-            self.log_probs[i] = dist.log_prob(action)
-            self.seq_label_delta = (1 - self.masks[i-1]) if i > 0 else 0
-            self.seq_labels[i] = self.seq_labels[i-1] + self.seq_label_delta if i > 0 \
-                                 else self.seq_labels[0]
-            if self.reshape_reward is not None:
-                self.rewards[i] = torch.tensor([
-                    self.reshape_reward(obs_, action_, reward_, done_)
-                    for obs_, action_, reward_, done_ in zip(next_obs, action, reward, done)
-                ], device=self.device)
-            else:
-                self.rewards[i] = torch.tensor(reward, device=self.device)
-
-            # update obs
-            self.obs = next_obs
-
-            # Update log values
-            self.log_episode_return += torch.tensor(reward, device=self.device, dtype=torch.float)
-            self.log_episode_reshaped_return += self.rewards[i]
-            self.log_episode_num_frames += torch.ones(self.num_procs, device=self.device)
-
-            for i, done_ in enumerate(done):
-                if done_:
-                    self.log_done_counter += 1
-                    self.log_return.append(self.log_episode_return[i].item())
-                    self.log_reshaped_return.append(self.log_episode_reshaped_return[i].item())
-                    self.log_num_frames.append(self.log_episode_num_frames[i].item())
-
-            self.log_episode_return *= self.mask
-            self.log_episode_reshaped_return *= self.mask
-            self.log_episode_num_frames *= self.mask
-
-        # ===== Add advantage and return to experiences =====
-        
-        preprocessed_obs = self.preprocess_obss(self.obs, device=self.device)
-
-        # bootstrapped final value for unfinished trajectories cut off by end
-        # of epoch (=num frames per proc)
-        with torch.no_grad():
-            _, next_value = self.acmodel(preprocessed_obs)
-
-        for i in reversed(range(self.num_frames_per_proc)):
-            next_mask = self.masks[i+1] if i < self.num_frames_per_proc - 1 else self.mask
-            next_value = self.values[i+1] if i < self.num_frames_per_proc - 1 else next_value
-            next_advantage = self.advantages[i+1] if i < self.num_frames_per_proc - 1 else 0
-
-            delta = self.rewards[i] + self.discount * next_value * next_mask - self.values[i]
-            self.advantages[i] = delta + self.discount * self.gae_lambda * next_advantage * next_mask
-
-        # Define experiences:
-        #   the whole experience is the concatenation of the experience
-        #   of each process.
-        # In comments below:
-        #   - T is self.num_frames_per_proc,
-        #   - P is self.num_procs,
-        #   - D is the dimensionality.
-        exps = DictList()
-        # exps.obs = [self.obss[i][j]
-        #             for j in range(self.num_procs)
-        #             for i in range(self.num_frames_per_proc)]
-        # T x P -> P x T -> (P * T) x 1
-        exps.mask = self.masks.transpose(0, 1).reshape(-1).unsqueeze(1)
-        # for all tensors below, T x P -> P x T -> P * T
-        exps.action = self.actions.transpose(0, 1).reshape(-1)
-        exps.reward = self.rewards.transpose(0, 1).reshape(-1)
-        exps.log_prob = self.log_probs.transpose(0, 1).reshape(-1)
-        exps.value = self.values.transpose(0, 1).reshape(-1)
-        exps.advantage = self.advantages.transpose(0, 1).reshape(-1)
-        exps.returnn = exps.value + exps.advantage
-        # normalize the advantage
-        exps.advantage = (exps.advantage - exps.advantage.mean())/exps.advantage.std()
-
-        # ===== Process data for calculating Q values from context =====
-
-        # Reshape obss -> tensor size (batch size=num_procs, seq len=frames per proc, *(image_dim))
-        obss_mat = [None]*(self.num_procs)
-        for i in range(self.num_procs):
-            obss_mat[i] = self.preprocess_obss([self.obss[j][i] for j in range(self.num_frames_per_proc)])
-        obss_mat = torch.cat(obss_mat).view(self.num_procs, *obss_mat[0].shape)
+        # Reshape embeddings -> tensor size (num_procs, frames_per_proc, *(embedding_size))
+        # T x P x D -> P x T x D
+        self.attn_obss = self.embeddings.transpose(0, 1)
 
         # Reshape actions -> tensor size (num_procs, frames_per_proc, action_space.n)
-        self.actions_mat = (torch.nn.functional.one_hot(self.actions.long())
+        # T x P x 1 -> P x T x action_space.n
+        self.attn_actions = (torch.nn.functional.one_hot(self.actions.long(), 7)
                             .transpose(0, 1).float())
 
         # Create block diagonal mask so observations from different
@@ -175,6 +93,21 @@ class AttentionQAlgo(BaseAlgo):
 
         # just for debugging
         self.seq_labels_debug = seq_labels
+        obss_mat = [None]*(self.num_procs)
+        for i in range(self.num_procs):
+            obss_mat[i] = torch.tensor(np.array([self.obss[j][i]["image"] for j
+                                                 in range(self.num_frames_per_proc)]),
+                                       device=self.device,
+                                       dtype=float)
+        self.obss_mat = torch.cat(obss_mat).view(self.num_procs, *obss_mat[0].shape)
+        # self.obss_mat is size (batch size=num_procs, seq len=frames per proc, *(image_dim))
+
+        with torch.no_grad():
+            qvalue, scores = self.qmodel(obs=self.attn_obss,
+                                         act=self.attn_actions,
+                                         mask_future=True,
+                                         custom_mask=self.attn_mask)
+        # TODO: use qvalues and scores to modify advantage for TVT (not yet implemented)
 
         # Log some values
 
@@ -192,37 +125,91 @@ class AttentionQAlgo(BaseAlgo):
         self.log_reshaped_return = self.log_reshaped_return[-self.num_procs:]
         self.log_num_frames = self.log_num_frames[-self.num_procs:]
 
-        return obss_mat, exps, logs
+        return exps, logs
 
-    def update_parameters(self, obss, exps):
+    def update_parameters(self, exps):
         self._update_number += 1
         logs = {}
 
-        # ===== Calculate losses =====
+        # ===== A2C loss =====
 
-        dist, value, qvalue, scores = self.acmodel(obss,
-                                                   actions=self.actions_mat,
-                                                   mask_future=True,
-                                                   attn_custom_mask=self.attn_mask)
+        # Compute starting indexes
+        inds = self._get_starting_indexes()
 
-        entropy = dist.entropy().mean()
+        # Initialize update values
+        update_entropy = 0
+        update_value = 0
+        update_policy_loss = 0
+        update_value_loss = 0
+        update_loss = 0
 
-        policy_loss = -(dist.log_prob(exps.action) * exps.advantage).mean()
+        # Initialize memory
 
-        value_loss = (value - exps.returnn).pow(2).mean()
+        if self.acmodel.recurrent:
+            memory = exps.memory[inds]
+
+        for i in range(self.recurrence):
+            # Create a sub-batch of experience
+
+            sb = exps[inds + i]
+
+            # Compute loss
+
+            if self.acmodel.recurrent and not self.store_embeddings:
+                dist, value, memory = self.acmodel(sb.obs, memory * sb.mask)
+            elif self.acmodel.recurrent and self.store_embeddings:
+                dist, value, memory, _ = self.acmodel(sb.obs, memory * sb.mask)
+            else:
+                dist, value = self.acmodel(sb.obs)
+
+            entropy = dist.entropy().mean()
+
+            policy_loss = -(dist.log_prob(sb.action) * sb.advantage).mean()
+
+            value_loss = (value - sb.returnn).pow(2).mean()
+
+            loss = policy_loss - self.entropy_coef * entropy + self.value_loss_coef * value_loss
+
+            # Update batch values
+
+            update_entropy += entropy.item()
+            update_value += value.mean().item()
+            update_policy_loss += policy_loss.item()
+            update_value_loss += value_loss.item()
+            update_loss += loss
+
+        # Update update values
+
+        update_entropy /= self.recurrence
+        update_value /= self.recurrence
+        update_policy_loss /= self.recurrence
+        update_value_loss /= self.recurrence
+        update_loss /= self.recurrence
+
+        # ===== Qvalue loss =====
+
+        qvalue, scores = self.qmodel(obs=self.attn_obss,
+                                     act=self.attn_actions,
+                                     mask_future=True,
+                                     custom_mask=self.attn_mask)
 
         qvalue_loss = (qvalue - exps.returnn).pow(2).mean()
-
-        loss = policy_loss - self.entropy_coef * entropy + self.value_loss_coef * value_loss \
-               + self.value_loss_coef * qvalue_loss
 
         # Update actor-critic
 
         self.optimizer.zero_grad()
-        loss.backward()
+        update_loss.backward()
         update_grad_norm = sum(p.grad.data.norm(2) ** 2 for p in self.acmodel.parameters()) ** 0.5
         torch.nn.utils.clip_grad_norm_(self.acmodel.parameters(), self.max_grad_norm)
         self.optimizer.step()
+
+        # Update Qvalue
+
+        self.qvalue_optimizer.zero_grad()
+        qvalue_loss.backward()
+        update_grad_norm_q = sum(p.grad.data.norm(2) ** 2 for p in self.qmodel.parameters()) ** 0.5
+        torch.nn.utils.clip_grad_norm_(self.qmodel.parameters(), self.max_grad_norm)
+        self.qvalue_optimizer.step()
 
         # Log some values
 
@@ -254,14 +241,19 @@ class AttentionQAlgo(BaseAlgo):
             mask_fig.savefig(mask_fig_base, fmt='png')
             plt.clf()
 
-            self.calculate_and_save_top_attended(scores0, obss[0].detach().numpy(),
+            self.calculate_and_save_top_attended(scores0, self.obss_mat[0].numpy(),
                                                  self.actions.detach()[:, 0].squeeze(),
                                                  out_dir=self.wandb_dir)
 
         with torch.no_grad():
             # evaluate KL divergence b/w old and new policy
             # policy under newly updated model
-            dist, _ = self.acmodel(obss)
+            if self.acmodel.recurrent and not self.store_embeddings:
+                dist, _, _ = self.acmodel(exps.obs, exps.memory * exps.mask)
+            elif self.acmodel.recurrent and self.store_embeddings:
+                dist, _, _, _ = self.acmodel(exps.obs, exps.memory * exps.mask)
+            else:
+                dist, _ = self.acmodel(exps.obs)
 
             approx_kl = (exps.log_prob - dist.log_prob(exps.action)).mean().item()
             adv_mean = exps.advantage.mean().item()
@@ -273,18 +265,20 @@ class AttentionQAlgo(BaseAlgo):
             value_std = value.std().item()
 
         logs.update({
-            "entropy": entropy.item(),
-            "value": value.mean().item(),
-            "value_max": value.max().item(),
-            "value_min": value.min().item(),
+            "entropy": update_entropy,
+            "value": update_value,
+            "value_max": exps.value.max().item(),
+            "value_min": exps.value.min().item(),
+            "value_std": exps.value.std().item(),
             "qvalue_mean": qvalue.mean().item(),
             "qvalue_min": qvalue.min().item(),
             "qvalue_max": qvalue.max().item(),
-            "value_std": value_std,
-            "policy_loss": policy_loss.item(),
-            "value_loss": value_loss.item(),
+            "qvalue_std": qvalue.std().item(),
+            "policy_loss": update_policy_loss,
+            "value_loss": update_value_loss,
             "qvalue_loss": qvalue_loss.item(),
             "grad_norm": update_grad_norm,
+            "grad_norm_q": update_grad_norm_q,
             "adv_max": adv_max,
             "adv_min": adv_min,
             "adv_mean": adv_mean,
@@ -350,34 +344,18 @@ class AttentionQAlgo(BaseAlgo):
         )
         return img
 
+    def _get_starting_indexes(self):
+        """Gives the indexes of the observations given to the model and the
+        experiences used to compute the loss at first.
 
-if __name__ == '__main__':
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    num_procs = 4
-    seed = 0
+        The indexes are the integers from 0 to `self.num_frames` with a step of
+        `self.recurrence`. If the model is not recurrent, they are all the
+        integers from 0 to `self.num_frames`.
 
-    envs = []
-    for i in range(num_procs):
-        envs.append(utils.make_env('MiniGrid-KeyGoal-6x6-v0', seed + 10000 * i))
-
-    obs_space, preprocess_obss = get_obss_preprocessor(envs[0].observation_space)
-    acmodel = AttentionQ(obs_space, envs[0].action_space,)
-
-    algo_args=dict(device=device,
-                   num_frames_per_proc=128,
-                   discount=1.,
-                   lr=0.001,
-                   gae_lambda=1.,
-                   entropy_coef=0.,
-                   value_loss_coef=0.5,
-                   max_grad_norm=0.5,
-                   recurrence=1,
-                   rmsprop_alpha=0.99,
-                   rmsprop_eps=1e-8,
-                   preprocess_obss=preprocess_obss)
-    algo = AttentionQAlgo(envs, acmodel, **algo_args)
-
-    total_frames = 0
-    obss, exps, logs = algo.collect_experiences()
-    algo.update_parameters(obss, exps)
-    total_frames += logs['num_frames']
+        Returns
+        -------
+        starting_indexes : list of int
+            the indexes of the experiences to be used at first
+        """
+        starting_indexes = np.arange(0, self.num_frames, self.recurrence)
+        return starting_indexes

--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -206,8 +206,14 @@ class BaseAlgo(ABC):
         # bootstrapped final value for unfinished trajectories cut off by end
         # of epoch (=num frames per proc)
         with torch.no_grad():
-            if self.acmodel.recurrent:
-                _, next_value, _ = self.acmodel(preprocessed_obs, self.memory * self.mask.unsqueeze(1))
+            if self.acmodel.recurrent and not self.store_embeddings:
+                _, next_value, _ = self.acmodel(
+                    preprocessed_obs, self.memory * self.mask.unsqueeze(1)
+                )
+            elif self.acmodel.recurrent and self.store_embeddings:
+                _, next_value, _, _ = self.acmodel(
+                    preprocessed_obs, self.memory * self.mask.unsqueeze(1)
+                )
             else:
                 _, next_value = self.acmodel(preprocessed_obs)
 

--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -9,7 +9,8 @@ class BaseAlgo(ABC):
     """The base class for RL algorithms."""
 
     def __init__(self, envs, acmodel, device, num_frames_per_proc, discount, lr, gae_lambda, entropy_coef,
-                 value_loss_coef, max_grad_norm, recurrence, preprocess_obss, reshape_reward):
+                 value_loss_coef, max_grad_norm, recurrence, preprocess_obss, reshape_reward,
+                 store_embeddings=False):
         """
         Initializes a `BaseAlgo` instance.
 
@@ -42,6 +43,9 @@ class BaseAlgo(ABC):
         reshape_reward : function
             a function that shapes the reward, takes an
             (observation, action, reward, done) tuple as an input
+        store_embeddings : bool
+            if True, store image or hidden state embeddings while stepping
+            through the env
         """
 
         # Store parameters
@@ -69,11 +73,13 @@ class BaseAlgo(ABC):
 
         self.acmodel.to(self.device)
         self.acmodel.train()
+        self.acmodel.return_embedding = store_embeddings
 
         # Store helpers values
 
         self.num_procs = len(envs)
         self.num_frames = self.num_frames_per_proc * self.num_procs
+        self.store_embeddings = store_embeddings
 
         # Initialize experience values
 
@@ -96,6 +102,9 @@ class BaseAlgo(ABC):
         self.seq_labels = torch.zeros(*shape, device=self.device)
         self.seq_label_delta = torch.zeros(shape[1], device=self.device)
 
+        if self.store_embeddings:
+            # if not recurrent, store the image embeddings, otherwise the hidden states
+            self.embeddings = torch.zeros(*shape, self.acmodel.semi_memory_size, device=self.device)
 
         # Initialize log values
 
@@ -134,18 +143,22 @@ class BaseAlgo(ABC):
 
             preprocessed_obs = self.preprocess_obss(self.obs, device=self.device)
             with torch.no_grad():
-                if self.acmodel.recurrent:
-                    dist, value, memory = self.acmodel(preprocessed_obs, self.memory * self.mask.unsqueeze(1))
+                if self.acmodel.recurrent and not self.store_embeddings:
+                    dist, value, memory = self.acmodel(preprocessed_obs,
+                                                       self.memory * self.mask.unsqueeze(1))
+                elif self.acmodel.recurrent and self.store_embeddings:
+                    dist, value, memory, embedding = self.acmodel(preprocessed_obs,
+                                                                  self.memory * self.mask.unsqueeze(1))
                 else:
                     dist, value = self.acmodel(preprocessed_obs)
             action = dist.sample()
 
-            obs, reward, done, _ = self.env.step(action.cpu().numpy())
+            next_obs, reward, done, _ = self.env.step(action.cpu().numpy())
 
             # Update experiences values
 
             self.obss[i] = self.obs
-            self.obs = obs
+            self.obs = next_obs
             if self.acmodel.recurrent:
                 self.memories[i] = self.memory
                 self.memory = memory
@@ -156,12 +169,19 @@ class BaseAlgo(ABC):
             if self.reshape_reward is not None:
                 self.rewards[i] = torch.tensor([
                     self.reshape_reward(obs_, action_, reward_, done_)
-                    for obs_, action_, reward_, done_ in zip(obs, action, reward, done)
+                    for obs_, action_, reward_, done_ in zip(next_obs, action, reward, done)
                 ], device=self.device)
             else:
                 self.rewards[i] = torch.tensor(reward, device=self.device)
             self.log_probs[i] = dist.log_prob(action)
 
+            # collect seq labels to use for masking, for attention only
+            self.seq_label_delta = (1 - self.masks[i-1]) if i > 0 else 0
+            self.seq_labels[i] = self.seq_labels[i-1] + self.seq_label_delta if i > 0 \
+                                 else self.seq_labels[0]
+
+            if self.acmodel.recurrent and self.store_embeddings:
+                self.embeddings[i] = embedding
             # Update log values
 
             self.log_episode_return += torch.tensor(reward, device=self.device, dtype=torch.float)
@@ -179,7 +199,7 @@ class BaseAlgo(ABC):
             self.log_episode_reshaped_return *= self.mask
             self.log_episode_num_frames *= self.mask
 
-        # Add advantage and return to experiences
+        # ===== Add advantage and return to experiences =====
 
         preprocessed_obs = self.preprocess_obss(self.obs, device=self.device)
 

--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -4,6 +4,7 @@ import torch
 from rl_credit.format import default_preprocess_obss
 from rl_credit.utils import DictList, ParallelEnv
 
+
 class BaseAlgo(ABC):
     """The base class for RL algorithms."""
 
@@ -90,6 +91,11 @@ class BaseAlgo(ABC):
         self.rewards = torch.zeros(*shape, device=self.device)
         self.advantages = torch.zeros(*shape, device=self.device)
         self.log_probs = torch.zeros(*shape, device=self.device)
+
+        # For attention only
+        self.seq_labels = torch.zeros(*shape, device=self.device)
+        self.seq_label_delta = torch.zeros(shape[1], device=self.device)
+
 
         # Initialize log values
 

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -44,12 +44,14 @@ def init_params(m):
 
 
 class ACModel(nn.Module, RecurrentACModel):
-    def __init__(self, obs_space, action_space, use_memory=False, use_text=False):
+    def __init__(self, obs_space, action_space, use_memory=False, use_text=False,
+                 return_embedding=False):
         super().__init__()
 
         # Decide which components are enabled
         self.use_text = use_text
         self.use_memory = use_memory
+        self.return_embedding = return_embedding
 
         # Define image embedding
         self.image_conv = nn.Sequential(
@@ -129,7 +131,13 @@ class ACModel(nn.Module, RecurrentACModel):
         x = self.critic(embedding)
         value = x.squeeze(1)
 
-        return dist, value, memory
+        if self.return_embedding:
+            # if no memory, embedding is the img embedding, otherwise
+            # it's the hidden state of the LSTM, also (redundantly) stored
+            # in memory.
+            return dist, value, memory, embedding
+        else:
+            return dist, value, memory
 
     def _get_embed_text(self, text):
         _, hidden = self.text_rnn(self.word_embedding(text))

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -584,3 +584,81 @@ class AttentionQ(nn.Module, BaseModel):
         qvalue = x.squeeze(1)
 
         return dist, value, qvalue, scores
+
+
+class QAttentionModel(nn.Module):
+    """Calculate Q value given embedding input and action context vectors
+    using attention.
+
+    Creates context from concatenating embedding and action inputs.
+
+    embedding_size : int
+       size of the embedding (assumed to be a 1-D vector, not a raw RGB image)
+
+    action_size : int
+       cardinality of the action space
+
+    d_key : int
+        rank of attention matrix
+    """
+    def __init__(self, embedding_size, action_size, d_key=30):
+        super().__init__()
+
+        self.d_key = d_key
+
+        self._action_embed_size = 32
+        self.action_embed = nn.Linear(action_size, self._action_embed_size)
+
+        self.Wq = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
+        self.Wk = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
+        self.Wv = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
+
+        self.Qvalue = nn.Sequential(
+            nn.Linear(d_key, 64),
+            nn.ReLU(),
+            nn.Linear(64, 1)
+        )
+
+    def forward(self, obs, act, mask_future=True, custom_mask=None):
+        """
+        obs : tensor, of size
+            (batch_size, sequence_length, embedding_size)
+
+        act : tensor, of size
+            (batch_size, sequence_length, action_cardinality).  Actions
+            should be one-hot encoded
+
+        mask_future: bool
+            Filter out attention to future values?
+
+        custom_mask: (optional) torch.tensor, dtype bool, of size
+            (batch_size, sequence_length, sequence_length), intended for masking
+            between different episodes in the same batch.
+        """
+        batch_sz, seq_len, _ = obs.shape
+
+        action_embedding = self.action_embed(act.reshape(batch_sz * seq_len, -1))
+
+        x = torch.cat((obs.reshape(batch_sz * seq_len, -1), action_embedding), dim=1)
+
+        # batch_sz x seq_len x d_key
+        queries = self.Wq(x).view(batch_sz, seq_len, self.d_key) / (self.d_key ** (1/4))
+        keys = self.Wk(x).view(batch_sz, seq_len, self.d_key) / (self.d_key ** (1/4))
+        values = self.Wv(x).view(batch_sz, seq_len, self.d_key)
+
+        scores = torch.bmm(queries, keys.transpose(1, 2))
+
+        if custom_mask is not None:
+            scores.masked_fill_(custom_mask, float('-inf'))
+
+        if mask_future is True:
+            future_mask = torch.ones([seq_len, seq_len]).tril()
+            scores.masked_fill_(future_mask == 0, float('-inf'))
+
+        scores = torch.softmax(scores, dim=2)  # batch_sz x seq_len x seq_len
+        attn_out = torch.bmm(scores, values)   # batch_sz x seq_len x d_key
+
+        x = self.Qvalue(attn_out.view(batch_sz * seq_len, self.d_key))
+        qvalue = x.squeeze(1)
+
+        return qvalue, scores


### PR DESCRIPTION
- refactor `BaseAlgo` so that attention algos can use it by defining optional attention mask attributes and storage for embeddings
- to allow qvalue models to make use of embeddings learned by a2c model, provide option for a2c to return embeddings in add'n to policy and value
- refactor `AttentionQAlgo` so that it uses separate a2c and Qvalue attention models.  So far a2c and policy learning are completely separate from Qvalue, but this is another step towards using Qvalues to modify the advantage fxn for policy gradient via TVT