### PR TITLE
Log last reward returned by env

### DIFF
--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -116,6 +116,7 @@ class BaseAlgo(ABC):
         self.log_return = [0] * self.num_procs
         self.log_reshaped_return = [0] * self.num_procs
         self.log_num_frames = [0] * self.num_procs
+        self.log_last_reward = [0] * self.num_procs
 
     def collect_experiences(self):
         """Collects rollouts and computes advantages.
@@ -188,12 +189,16 @@ class BaseAlgo(ABC):
             self.log_episode_reshaped_return += self.rewards[i]
             self.log_episode_num_frames += torch.ones(self.num_procs, device=self.device)
 
-            for i, done_ in enumerate(done):
+            # loop through done status of each proc
+            for j, done_ in enumerate(done):
                 if done_:
                     self.log_done_counter += 1
-                    self.log_return.append(self.log_episode_return[i].item())
-                    self.log_reshaped_return.append(self.log_episode_reshaped_return[i].item())
-                    self.log_num_frames.append(self.log_episode_num_frames[i].item())
+                    self.log_return.append(self.log_episode_return[j].item())
+                    self.log_reshaped_return.append(self.log_episode_reshaped_return[j].item())
+                    self.log_num_frames.append(self.log_episode_num_frames[j].item())
+
+                    # log final reward
+                    self.log_last_reward.append(self.rewards[i, j].item())
 
             self.log_episode_return *= self.mask
             self.log_episode_reshaped_return *= self.mask
@@ -264,13 +269,15 @@ class BaseAlgo(ABC):
             "return_per_episode": self.log_return[-keep:],
             "reshaped_return_per_episode": self.log_reshaped_return[-keep:],
             "num_frames_per_episode": self.log_num_frames[-keep:],
-            "num_frames": self.num_frames
+            "num_frames": self.num_frames,
+            "last_reward_per_episode": self.log_last_reward[-keep:]
         }
 
         self.log_done_counter = 0
         self.log_return = self.log_return[-self.num_procs:]
         self.log_reshaped_return = self.log_reshaped_return[-self.num_procs:]
         self.log_num_frames = self.log_num_frames[-self.num_procs:]
+        self.log_last_reward = self.log_last_reward[-self.num_procs:]
 
         return exps, logs
 

--- a/rl_credit/scripts/train.py
+++ b/rl_credit/scripts/train.py
@@ -237,6 +237,7 @@ while num_frames < args.frames:
         return_per_episode = utils.synthesize(logs["return_per_episode"])
         rreturn_per_episode = utils.synthesize(logs["reshaped_return_per_episode"])
         num_frames_per_episode = utils.synthesize(logs["num_frames_per_episode"])
+        last_reward_per_episode = utils.synthesize(logs["last_reward_per_episode"])
 
         header = ["update", "frames", "FPS", "duration"]
         data = [update, num_frames, fps, duration]
@@ -280,10 +281,12 @@ while num_frames < args.frames:
     if args.wandb is not None:
         logs['returns_per_episode_std'] = np.std(logs.pop('return_per_episode'))
         logs['num_frames_per_episode_std'] = np.std(logs.pop('num_frames_per_episode'))
+        logs['last_reward_per_episode_std'] = np.std(logs.pop('last_reward_per_episode'))
         logs.pop('reshaped_return_per_episode')
         for x in ('mean', 'min', 'max'):
             logs[f'return_per_episode_{x}'] = return_per_episode[x]
             logs[f'frames_per_episode_{x}'] = num_frames_per_episode[x]
+            logs[f'last_reward_per_episode_{x}'] = last_reward_per_episode[x]
         logs['update_number'] = update
         logs['elapsed_time'] = duration
         wandb.log(logs, step=num_frames)


### PR DESCRIPTION
In lieue of more complicated assuming env has method to get all the rewards from last phase, if it is a multiphase env.  For the multiphase env experiments, set up so that the only rewards in the last phase correspond to the final reward upon completing task