### PR TITLE
Expt

### DIFF
--- a/examples/distractor_delay_expt.py
+++ b/examples/distractor_delay_expt.py
@@ -1,0 +1,89 @@
+import wandb
+
+from rl_credit.environment import (
+    DISCOUNT_TIMESCALE,
+    DISCOUNT_FACTOR,
+)
+from train import train
+
+
+####################################################
+# Config params shared among all experiments
+
+common_train_config = dict(
+    seed=1,
+    num_procs=16,
+    save_interval=20,
+    total_frames=0.1*10**6,
+    log_interval=1,
+)
+
+common_algo_kwargs = dict(
+    num_frames_per_proc=200,
+    discount=DISCOUNT_FACTOR,
+    lr=0.001,
+    gae_lambda=0.95,
+    entropy_coef=0.01,
+    value_loss_coef=0.5,
+    max_grad_norm=0.5,
+    rmsprop_alpha=0.99,
+    rmsprop_eps=1e-8,
+    reshape_reward=None,
+)
+
+
+####################################################
+# Experiment-specific configs
+
+# experiment 1
+expt_train_config = dict(
+    env_id='GiftDistractorDelay0-v0',
+    model_dir_stem='a2c_mem10_giftdelay0',
+    algo_name='a2c',
+    recurrence=10,
+)
+expt_algo_kwargs = {}
+
+# wandb metadata (tags, notes)
+delay_factor = 'delay_factor=0'
+delay_steps = 'delay_steps=0'
+wandb_notes = 'A2C with recurrence=10 with gift env delay=0'
+
+
+# experiment 2
+# expt_train_config = dict(
+#     env=Delay0_5Gifts,
+#     model_name='',
+#     model_dir='',
+#     algo_name='a2c',
+#     recurrence=10,
+# )
+# delay_factor = 'delay_factor=0.5'
+# delay_steps = 'delay_steps=50'
+
+
+if __name__ == '__main__':
+    wandb_params = {}
+    algo_kwargs = common_algo_kwargs
+    algo_kwargs.update(expt_algo_kwargs)
+
+    train_config = common_train_config
+    train_config.update(expt_train_config)
+
+    train_config.update({'algo_kwargs': algo_kwargs})
+
+    wandb_params.update(train_config)
+    wandb_params.update(common_algo_kwargs)
+    wandb_name = f"{train_config['algo_name']}|mem={train_config['recurrence']}|{train_config['env_id']}"
+
+    wandb.init(
+        project="distractor_time_delays",
+        config=wandb_params,
+        name=wandb_name,
+        tags=[train_config['algo_name'], delay_factor, delay_steps, train_config['env_id']],
+        notes=wandb_notes
+    )
+
+    wandb_dir = wandb.run.dir
+    train_config.update({'wandb_dir': wandb_dir})
+    train(**train_config)

--- a/examples/train.py
+++ b/examples/train.py
@@ -1,0 +1,198 @@
+import os
+import sys
+import shutil
+
+import time
+import datetime
+import numpy as np
+import torch
+import wandb
+
+import rl_credit
+import rl_credit.script_utils as utils
+from rl_credit.model import ACModel
+
+
+def train(env_id,
+          model_dir_stem,
+          wandb_dir,
+          seed=1,
+          num_procs=16,
+          save_interval=20,
+          total_frames=3*10**6,
+          log_interval=1,
+          algo_name='a2c',
+          algo_kwargs={},
+          recurrence=10,
+):
+    """
+    env_id (str) : id of registered gym environment
+
+    model_dir_stem (str) : name of dir under 'storage' folder 
+        containing the model status dict and local logs
+
+    wandb_dir (str) : wandb.run.dir, the location of wandb run output
+
+    seed (int) : random seed (default: 1)
+
+    num_procs (int) : number of processes (default: 16)
+
+    save_interval (int) : number of updates between two saves
+        (default: 20, 0 means no saving)
+
+    total_frames (int) : total number of frames of training
+        (default: 3e7)
+
+    log_interval (int) : number of updates between two logs
+        (default: 1)
+
+    algo_name (str) : name of algorithm, only a2c supported
+
+    algo_kwargs (dict) : kwargs to pass into algorithm
+
+    recurrence (int) : number of time-steps gradient is backpropagated 
+        (default: 10). If > 1, a LSTM is added to the model to have memory.
+    """
+    # set run dir
+    model_dir = utils.get_model_dir(model_dir_stem)
+
+    # Load loggers
+    txt_logger = utils.get_txt_logger(model_dir)
+    csv_file, csv_logger = utils.get_csv_logger(model_dir)
+
+    # Log command and all script arguments
+    txt_logger.info("{}\n".format(sys.argv[0]))
+
+    # Set seed for all randomness sources
+    utils.seed(seed)
+
+    # Set device
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    txt_logger.info(f"Device: {device}\n")
+
+    # Load environments
+    envs = []
+    for i in range(num_procs):
+        envs.append(utils.make_env(env_id, seed + 10000 * i))
+    txt_logger.info("Environments loaded\n")
+
+    # Load training status
+    try:
+        status = utils.get_status(model_dir)
+    except OSError:
+        status = {"num_frames": 0, "update": 0}
+    txt_logger.info("Training status loaded\n")
+
+    if "optimizer_state" in status:
+        algo.optimizer.load_state_dict(status["optimizer_state"])
+    txt_logger.info("Optimizer loaded\n")
+
+    # Load observations preprocessor
+    obs_space, preprocess_obss = utils.get_obss_preprocessor(envs[0].observation_space)
+    if "vocab" in status:
+        preprocess_obss.vocab.load_vocab(status["vocab"])
+    txt_logger.info("Observations preprocessor loaded")
+
+    # Load model
+    use_mem = recurrence > 1
+    if algo_name == 'a2c':
+        acmodel = ACModel(obs_space, envs[0].action_space, use_mem, False)
+    else:
+        raise ValueError("Unrecognized algo")
+
+    if "model_state" in status:
+        acmodel.load_state_dict(status["model_state"])
+    acmodel.to(device)
+    txt_logger.info("Model loaded\n")
+    txt_logger.info("{}\n".format(acmodel))
+
+    # Load algo
+    algo_kwargs.update({'acmodel': acmodel,
+                        'envs': envs,
+                        'device': device,
+                        'recurrence': recurrence,
+                        'preprocess_obss': preprocess_obss})
+    if algo_name == 'a2c':
+        algo = rl_credit.A2CAlgo(**algo_kwargs)
+
+    # Main training loop
+
+    num_frames = status["num_frames"]
+    update = status["update"]
+    start_time = time.time()
+
+    while num_frames < total_frames:
+
+        update_start_time = time.time()
+
+        exps, logs1 = algo.collect_experiences()
+        logs2 = algo.update_parameters(exps)
+
+        logs = {**logs1, **logs2}
+
+        update_end_time = time.time()
+
+        num_frames += logs["num_frames"]
+        update += 1
+
+        # Print logs
+        if update % log_interval == 0:
+            fps = logs["num_frames"]/(update_end_time - update_start_time)
+            duration = int(time.time() - start_time)
+            return_per_episode = utils.synthesize(logs["return_per_episode"])
+            rreturn_per_episode = utils.synthesize(logs["reshaped_return_per_episode"])
+            num_frames_per_episode = utils.synthesize(logs["num_frames_per_episode"])
+            last_reward_per_episode = utils.synthesize(logs["last_reward_per_episode"])
+
+            header = ["update", "frames", "FPS", "duration"]
+            data = [update, num_frames, fps, duration]
+            header += ["rreturn_" + key for key in rreturn_per_episode.keys()]
+            data += rreturn_per_episode.values()
+            header += ["num_frames_" + key for key in num_frames_per_episode.keys()]
+            data += num_frames_per_episode.values()
+            header += ["entropy", "value", "policy_loss", "value_loss", "grad_norm"]
+            data += [logs["entropy"], logs["value"], logs["policy_loss"], logs["value_loss"], logs["grad_norm"]]
+
+            txt_logger_output = "U {} | F {:06} | FPS {:04.0f} | D {} | rR:μσmM {:.2f} {:.2f} {:.2f} {:.2f} | F:μσmM {:.1f} {:.1f} {} {} | H {:.3f} | V {:.3f} | pL {:.3f} | vL {:.3f} | ∇ {:.3f}"
+
+            if "hca_loss" in logs:
+                txt_logger_output += " | hca {:.2f}"
+                header += ["hca_loss"]
+                data += [logs["hca_loss"]]
+            txt_logger.info(txt_logger_output.format(*data))
+
+            header += ["return_" + key for key in return_per_episode.keys()]
+            data += return_per_episode.values()
+
+            header += ["last_reward_" + key for key in last_reward_per_episode.keys()]
+            data += last_reward_per_episode.values()
+
+            if status["num_frames"] == 0:
+                csv_logger.writerow(header)
+            csv_logger.writerow(data)
+            csv_file.flush()
+
+        if save_interval > 0 and update % save_interval == 0:
+            status = {"num_frames": num_frames, "update": update,
+                      "model_state": acmodel.state_dict(),
+                      "optimizer_state": algo.optimizer.state_dict()}
+            if hasattr(preprocess_obss, "vocab"):
+                status["vocab"] = preprocess_obss.vocab.vocab
+            utils.save_status(status, model_dir)
+            txt_logger.info("Status saved")
+
+        # Wandb logging
+        logs['returns_per_episode_std'] = np.std(logs.pop('return_per_episode'))
+        logs['num_frames_per_episode_std'] = np.std(logs.pop('num_frames_per_episode'))
+        logs['last_reward_per_episode_std'] = np.std(logs.pop('last_reward_per_episode'))
+        logs.pop('reshaped_return_per_episode')
+        for x in ('mean', 'min', 'max'):
+            logs[f'return_per_episode_{x}'] = return_per_episode[x]
+            logs[f'frames_per_episode_{x}'] = num_frames_per_episode[x]
+            logs[f'last_reward_per_episode_{x}'] = last_reward_per_episode[x]
+        logs['update_number'] = update
+        logs['elapsed_time'] = duration
+        wandb.log(logs, step=num_frames)
+
+    # At end of run, copy model dir into wandb dir (includes csv logs and model dict)
+    shutil.copytree(model_dir, os.path.join(wandb_dir, 'model'))

--- a/rl_credit/__init__.py
+++ b/rl_credit/__init__.py
@@ -1,3 +1,11 @@
 from rl_credit.algos import A2CAlgo, PPOAlgo, HCAReturns, HCAState, AttentionAlgo, AttentionQAlgo
 from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla, ACModelReturnHCA, ACAttention, AttentionQ
 from rl_credit.utils import DictList
+
+
+from gym.envs.registration import register
+
+register(
+    id='GiftDistractorDelay0-v0',
+    entry_point='rl_credit.environment:Delay0_Gifts'
+)

--- a/rl_credit/environment.py
+++ b/rl_credit/environment.py
@@ -1,0 +1,85 @@
+from gym_minigrid.envs.delayed_reward_multiphase import ThreePhaseDelayedReward
+from gym_minigrid.envs.opengifts import GiftsEnv
+from gym_minigrid.envs.goalkeyoptional import GoalKeyOptionalEnv
+
+
+# gamma = 0.99
+DISCOUNT_FACTOR = 0.99
+DISCOUNT_TIMESCALE = 100
+
+STEPS_IN_PHASE1 = 50
+
+
+class KeyGiftsGoalBaseEnv(ThreePhaseDelayedReward):
+
+    def __init__(self, distractor_kwargs):
+        super().__init__(
+            key_kwargs=dict(
+                size=6,
+                key_color='yellow',
+                start_by_key=False,
+                max_steps=STEPS_IN_PHASE1,
+                done_when_fetched=False,
+            ),
+            distractor_kwargs=distractor_kwargs,
+            distractor_env=GiftsEnv,
+            delayed_reward_env=GoalKeyOptionalEnv,
+            delayed_reward_kwargs=dict(
+                size=8,
+                key_color=None,
+                max_steps=2*8**2,
+                goal_reward=5.,
+                key_reward=20.,
+            )
+        )
+
+
+class VaryGiftsGoalEnv(KeyGiftsGoalBaseEnv):
+
+    def __init__(self, distractor_xtra_kwargs):
+
+        assert 'max_steps' in distractor_xtra_kwargs.keys()
+
+        distractor_kwargs=dict(
+            size=6,
+            num_objs=4,
+            gift_reward=5,
+            max_steps=0.5*DISCOUNT_TIMESCALE,
+            done_when_all_opened=False,
+        )
+        distractor_kwargs.update(distractor_xtra_kwargs)
+
+        super().__init__(distractor_kwargs=distractor_kwargs)
+
+
+####################################################
+# Environments: Time delays in distractor phase
+
+class Delay0_Gifts(VaryGiftsGoalEnv):
+    def __init__(self):
+        distractor_xtra_kwargs = {'max_steps': 0.0 * DISCOUNT_TIMESCALE}
+        super().__init__(distractor_xtra_kwargs)
+
+
+class Delay0_5_Gifts(VaryGiftsGoalEnv):
+    def __init__(self):
+        distractor_xtra_kwargs = {'max_steps': 0.5 * DISCOUNT_TIMESCALE}
+        super().__init__(distractor_xtra_kwargs)
+
+
+####################################################
+# Reward size in distractor phase
+
+class Mean0_Gifts(VaryGiftsGoalEnv):
+    distractor_xtra_kwargs = {'gift_reward': 0}
+
+
+####################################################
+# Reward variance in distractor phase
+
+class Var0_Gifts(VaryGiftsGoalEnv):
+    distractor_xtra_kwargs = {'gift_reward': [5, 5]}
+
+
+class Var2_Gifts(VaryGiftsGoalEnv):
+    distractor_xtra_kwargs = {'gift_reward': [3, 7]}


### PR DESCRIPTION
- create foundational environment for experiments (all experiments revolve around varying phase 2, distractor rewards) and register one of the envs
- distractor_delay_expt.py is the script for varying time delays in phase 2.  contains shared and experiment-specific configs in the script.  All experiments in this script will write to the same wandb project `distractor_time_delays`
- create a refactored version of `scripts/train.py` in examples/ for running experiments.  Train has a function for passing experiment param config kwargs (instead of command line args).