### PR TITLE
Envyaml

### DIFF
--- a/.amlignore
+++ b/.amlignore
@@ -1,0 +1,7 @@
+.ipynb_checkpoints
+azureml-logs
+.azureml
+.git
+outputs
+azureml-setup
+docs

--- a/.amlignore
+++ b/.amlignore
@@ -5,3 +5,5 @@ azureml-logs
 outputs
 azureml-setup
 docs
+wandb/
+storage

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build/*
 dist/*
 *~
+.azureml/*
+src/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 *~
 .azureml/*
 src/*
+conda_dependencies.yml

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: rl-credit
+channels:
+  - pytorch
+dependencies:
+  - python=3.7
+  - pytorch>=1.0.0
+  - torchvision
+  - numpy>=1.13.0
+  - matplotlib
+  - seaborn
+  - pip
+  - pip:
+    - -e git+https://github.com/frangipane/gym-minigrid.git@master#egg=gym_minigrid
+    - wandb

--- a/rl_credit/examples/__init__.py
+++ b/rl_credit/examples/__init__.py
@@ -15,3 +15,18 @@ register(
     id='GiftDistractorDelay1-v0',
     entry_point='rl_credit.examples.distractor_delay_expt:Delay1_Gifts'
 )
+
+register(
+    id='GiftDistractorReward0-v0',
+    entry_point='rl_credit.examples.distractor_mean_expt:Reward0_Gifts'
+)
+
+register(
+    id='GiftDistractorReward1-v0',
+    entry_point='rl_credit.examples.distractor_mean_expt:Reward1_Gifts'
+)
+
+register(
+    id='GiftDistractorReward5-v0',
+    entry_point='rl_credit.examples.distractor_mean_expt:Reward5_Gifts'
+)

--- a/rl_credit/examples/distractor_mean_expt.py
+++ b/rl_credit/examples/distractor_mean_expt.py
@@ -1,0 +1,151 @@
+import numpy as np
+import gym
+import wandb
+
+from rl_credit.examples.environment import (
+    DISCOUNT_FACTOR,
+    VaryGiftsGoalEnv,
+)
+from rl_credit.examples.train import train
+
+
+DISCOUNT_TIMESCALE = int(np.round(1/(1 - DISCOUNT_FACTOR)))
+DELAY_STEPS = 0.5 * DISCOUNT_TIMESCALE
+
+
+####################################################
+# Environments: Mean reward size in distractor phase (0 variance)
+
+
+class Reward0_Gifts(VaryGiftsGoalEnv):
+    def __init__(self):
+        distractor_xtra_kwargs = {'max_steps': DELAY_STEPS, 'gift_reward': 0}
+        super().__init__(distractor_xtra_kwargs)
+
+
+class Reward1_Gifts(VaryGiftsGoalEnv):
+    def __init__(self):
+        distractor_xtra_kwargs = {'max_steps': DELAY_STEPS, 'gift_reward': 1}
+        super().__init__(distractor_xtra_kwargs)
+
+
+class Reward5_Gifts(VaryGiftsGoalEnv):
+    def __init__(self):
+        distractor_xtra_kwargs = {'max_steps': DELAY_STEPS, 'gift_reward': 5}
+        super().__init__(distractor_xtra_kwargs)
+
+
+####################################################
+# Config params shared among all experiments
+
+common_train_config = dict(
+    num_procs=16,
+    save_interval=300,
+    total_frames=16*600*1000,  #9_600_000
+    log_interval=1,
+)
+
+common_algo_kwargs = dict(
+    num_frames_per_proc=600,
+    discount=DISCOUNT_FACTOR,
+    lr=0.001,
+    gae_lambda=0.95,
+    entropy_coef=0.01,
+    value_loss_coef=0.5,
+    max_grad_norm=0.5,
+    rmsprop_alpha=0.99,
+    rmsprop_eps=1e-8,
+    reshape_reward=None,
+)
+
+delay_steps = f'delay_steps={DELAY_STEPS}'
+
+
+####################################################
+# Experiment-specific configs
+
+##************ experiment 1 ************
+model_dir_stem='a2c_mem10_giftreward0'
+expt_train_config = dict(
+    env_id='GiftDistractorReward0-v0',
+    algo_name='a2c',
+    recurrence=10,
+)
+expt_algo_kwargs = {}
+
+# wandb metadata (tags, notes)
+distractor_reward = 'gift_reward=0'
+wandb_notes = 'A2C with recurrence=10, gift reward=0, delay=50 steps'
+
+
+##************ experiment 2 ************
+# model_dir_stem='a2c_mem10_giftreward1'
+# expt_train_config = dict(
+#     env_id='GiftDistractorReward1-v0',
+#     algo_name='a2c',
+#     recurrence=10,
+# )
+# expt_algo_kwargs = {}
+# distractor_reward = 'gift_reward=1'
+# wandb_notes = 'A2C with recurrence=10, gift reward=1, delay=50 steps'
+
+
+##************ experiment 3 ************
+# model_dir_stem='a2c_mem10_giftreward5'
+# expt_train_config = dict(
+#     env_id='GiftDistractorReward5-v0',
+#     algo_name='a2c',
+#     recurrence=10,
+# )
+# expt_algo_kwargs = {}
+# distractor_reward = 'gift_reward=5'
+# wandb_notes = 'A2C with recurrence=10, gift reward=5, delay=50 steps'
+
+
+def main(seed):
+    wandb_params = {}
+    algo_kwargs = common_algo_kwargs
+    algo_kwargs.update(expt_algo_kwargs)
+
+    train_config = common_train_config
+    expt_train_config['model_dir_stem'] = f"{model_dir_stem}_seed{seed}"
+    train_config.update(expt_train_config)
+    train_config['seed'] = seed
+
+    train_config.update({'algo_kwargs': algo_kwargs})
+
+    # expt run params to record in wandb
+    wandb_params.update(train_config)
+    wandb_params.update(common_algo_kwargs)
+    wandb_params.update({'env_params': str(vars(gym.make(train_config['env_id'])))})
+    wandb_name = f"{train_config['algo_name']}|mem={train_config['recurrence']}|{train_config['env_id']}"
+
+    wandb.init(
+        project="distractor_reward_size",
+        config=wandb_params,
+        name=wandb_name,
+        tags=[train_config['algo_name'],
+              distractor_reward,
+              delay_steps,
+              train_config['env_id'],
+              f'discount_timescale={DISCOUNT_TIMESCALE}',
+              f"discount_factor={DISCOUNT_FACTOR}"],
+        notes=wandb_notes,
+        reinit=True,
+        group=wandb_name,
+        job_type='training',
+    )
+
+    wandb_dir = wandb.run.dir
+    train_config.update({'wandb_dir': wandb_dir})
+    train(**train_config)
+
+    wandb.join()
+
+
+if __name__ == '__main__':
+    # Number of runs to average over per experiment
+    seeds = range(5)
+
+    for seed in seeds:
+        main(seed)

--- a/rl_credit/scripts/train.py
+++ b/rl_credit/scripts/train.py
@@ -3,7 +3,6 @@ import time
 import datetime
 import torch
 import rl_credit
-import tensorboardX
 import sys
 import numpy as np
 import os
@@ -87,11 +86,10 @@ default_model_name = f"{args.env}_{args.algo}_seed{args.seed}_{date}"
 model_name = args.model or default_model_name
 model_dir = utils.get_model_dir(model_name)
 
-# Load loggers and Tensorboard writer
+# Load loggers
 
 txt_logger = utils.get_txt_logger(model_dir)
 csv_file, csv_logger = utils.get_csv_logger(model_dir)
-#tb_writer = tensorboardX.SummaryWriter(model_dir)
 
 # Log command and all script arguments
 

--- a/scripts/create-azure-runconfig.py
+++ b/scripts/create-azure-runconfig.py
@@ -1,0 +1,81 @@
+"""Script to generate a runconfig for the Azure ML CLI.
+
+1. First attach the directory(workspace) to Azure.
+2. Then run this script in the attached workspace.
+
+This script assumes many things, e.g.
+
+1. assumes the directory contains environment.yml, a conda environment
+file, and a python script rl_credit/examples/distractor_delay_expt.py.
+
+2. Assumes you have an existing compute target called "gpu-cluster".
+Alternatively, you can specify "amlcompute" with vm_size.  The vm_size in this 
+example does not actually do anything because it's using an existing target.
+
+https://github.com/microsoft/MLOps/blob/master/examples/cli-train-deploy/generate-runconfig.py
+
+To use the output of the script
+
+1. cd to the workspace directory
+2. Make sure you don't have your conda environment activated
+3. Type on the command line:
+az ml run submit-script -c train -e rl-credit --path .azureml --source-directory .
+
+Note, the input for -c is "train", which corresponds to "train.runconfig" generated
+by this script.  -e is the Name of the machine learning experiment under your workspace.
+--path to root directory for run config files.
+"""
+import os
+
+from azureml.core import Workspace, Run, Environment, ScriptRunConfig
+from azureml.core.conda_dependencies import CondaDependencies
+from azureml.core.experiment import Experiment
+from azureml.core.runconfig import RunConfiguration
+from azureml.core.script_run_config import get_run_config_from_script_run
+
+# load Workspace
+ws = Workspace.from_config()
+
+# load Experiment
+experiment = Experiment(workspace=ws, name='rl-credit')
+
+# Create python environment for Azure machine learning expt
+# options for class methods: from_conda_specification, from_pip_requirements,
+# from_existing_conda_environment
+myenv = Environment(name="rl-credit")
+
+
+## Environment: docker section
+myenv.docker.enabled = True
+myenv.docker.base_image = "mcr.microsoft.com/azureml/base-gpu:openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04"
+# comment out this environment variable if you don't have it set!
+myenv.environment_variables = {'WANDB_API_KEY': os.environ['WANDB_API_KEY']}
+
+## Environment: python section
+conda_dep = CondaDependencies(conda_dependencies_file_path='environment.yml')
+myenv.python.conda_dependencies = conda_dep
+
+# create configuration for Run
+# Use RunConfiguration to specify compute target / env deps part of run
+run_config = RunConfiguration()
+
+# Attach compute target to run config
+run_config.framework = 'python'
+run_config.target = "gpu-cluster"
+# This doesn't actuallly do anything since my target is a persistent compute instead of amlcompute
+run_config.amlcompute.vm_size = "Standard_NC24"
+run_config.node_count = 1
+run_config.environment = myenv
+
+
+# ScriptRunConfig packaages together environment configuration of
+# RunConfiguration with a script for training to create a **script** run.
+""" RunConfiguration(script=None, arguments=None, framework=None, communicator=None,
+ conda_dependencies=None, _history_enabled=None, _path=None, _name=None)
+"""
+src = ScriptRunConfig(source_directory='.',
+                      script='rl_credit/examples/distractor_delay_expt.py',
+                      run_config=run_config)
+
+
+get_run_config_from_script_run(src).save(path='.azureml/train.runconfig')

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,5 @@ setup(
         "torch>=1.0.0",
         "gym-minigrid",
         "matplotlib",
-        "tensorboardX>=1.6"
     ]
 )


### PR DESCRIPTION
- create environment.yml (conda virtual env), to be used with azure ml
- create configs for distractor_mean_expt.py (varying reward sizes in distractor phase)
- add helper script for creating config for azure ml runs under new top level dir `scripts/`
- tested run on azure, works, e.g. command line `az ml run submit-script -c .azureml/train -e rl-credit`