### PR TITLE
Tvt

### DIFF
--- a/rl_credit/__init__.py
+++ b/rl_credit/__init__.py
@@ -1,3 +1,4 @@
 from rl_credit.algos import A2CAlgo, PPOAlgo, HCAReturns, HCAState, AttentionAlgo, AttentionQAlgo
 from rl_credit.model import ACModel, RecurrentACModel, ACModelVanilla, ACModelReturnHCA, ACAttention, AttentionQ
 from rl_credit.utils import DictList
+from rl_credit.examples import *

--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -73,6 +73,22 @@ class AttentionQAlgo(BaseAlgo):
 
         # ===== Calculate Qvalues using attention (context from experiences) =====
 
+        # TODO: use qvalues and scores to modify advantage for TVT (not yet implemented)
+        self.qvalue, self.scores = self.get_attention_scores()
+
+
+        # Log some values
+
+        keep = max(self.log_done_counter, self.num_procs)
+
+        return exps, logs
+
+    def get_attention_scores(self):
+        """
+        Classify obs and get attention scores from the classifier network.
+        Classifier is a binary classifier that tries to predict if returns for an obs
+        are greater than a threshold.
+        """
         # if self.acmodel.recurrent:
         #     # Concat image embedding with hidden state
         #     # Reshape embeddings -> (num_procs, frames_per_proc, *(2*embedding_size))
@@ -116,17 +132,7 @@ class AttentionQAlgo(BaseAlgo):
                                          act=self.attn_actions,
                                          mask_future=True,
                                          custom_mask=self.attn_mask)
-        # TODO: use qvalues and scores to modify advantage for TVT (not yet implemented)
-
-        # for debugging
-        self.qvalue = qvalue
-        self.scores = scores
-
-        # Log some values
-
-        keep = max(self.log_done_counter, self.num_procs)
-
-        return exps, logs
+        return qvalue, scores
 
     def update_parameters(self, exps):
         self._update_number += 1

--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -113,18 +113,6 @@ class AttentionQAlgo(BaseAlgo):
 
         keep = max(self.log_done_counter, self.num_procs)
 
-        logs = {
-            "return_per_episode": self.log_return[-keep:],
-            "reshaped_return_per_episode": self.log_reshaped_return[-keep:],
-            "num_frames_per_episode": self.log_num_frames[-keep:],
-            "num_frames": self.num_frames
-        }
-
-        self.log_done_counter = 0
-        self.log_return = self.log_return[-self.num_procs:]
-        self.log_reshaped_return = self.log_reshaped_return[-self.num_procs:]
-        self.log_num_frames = self.log_num_frames[-self.num_procs:]
-
         return exps, logs
 
     def update_parameters(self, exps):

--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -181,7 +181,11 @@ class AttentionQAlgo(BaseAlgo):
                                      mask_future=True,
                                      custom_mask=self.attn_mask)
 
-        qvalue_loss = (qvalue - exps.returnn).pow(2).mean()
+        #qvalue_loss = (qvalue - exps.returnn).pow(2).mean()
+        #import pdb; pdb.set_trace()
+        y_target = (exps.returnn > 15.).long()
+        ce_loss = torch.nn.CrossEntropyLoss()
+        qvalue_loss = ce_loss(qvalue, y_target)
 
         # Update actor-critic
 
@@ -272,6 +276,8 @@ class AttentionQAlgo(BaseAlgo):
             "adv_mean": adv_mean,
             "adv_std": adv_std,
             "kl": approx_kl,
+            "num_returns_above_thresh": y_target.sum().item(),
+            "frac_returns_above_thresh": y_target.sum().item()/len(y_target)
         })
         return logs
 

--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -118,6 +118,10 @@ class AttentionQAlgo(BaseAlgo):
                                          custom_mask=self.attn_mask)
         # TODO: use qvalues and scores to modify advantage for TVT (not yet implemented)
 
+        # for debugging
+        self.qvalue = qvalue
+        self.scores = scores
+
         # Log some values
 
         keep = max(self.log_done_counter, self.num_procs)
@@ -192,9 +196,9 @@ class AttentionQAlgo(BaseAlgo):
 
         #qvalue_loss = (qvalue - exps.returnn).pow(2).mean()
         #import pdb; pdb.set_trace()
-        y_target = (exps.returnn > 15.).long()
-        ce_loss = torch.nn.CrossEntropyLoss()
-        qvalue_loss = ce_loss(qvalue, y_target)
+        y_target = (exps.returnn > 17.).float().unsqueeze(1)
+        pos_weight = torch.tensor([2])
+        qvalue_loss = F.binary_cross_entropy_with_logits(qvalue, y_target, pos_weight=pos_weight)
 
         # Update actor-critic
 

--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -266,7 +266,7 @@ class BaseAlgo(ABC):
 
         exps.obs = self.preprocess_obss(exps.obs, device=self.device)
 
-        # TODO remove, for debugging only
+        # for debugging only
         self.exps = exps
 
         # Log some values

--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -101,6 +101,7 @@ class BaseAlgo(ABC):
         # For attention only
         self.seq_labels = torch.zeros(*shape, device=self.device)
         self.seq_label_delta = torch.zeros(shape[1], device=self.device)
+        self.rewards_togo = torch.zeros(*shape, device=self.device)
 
         if self.store_embeddings:
             # if not recurrent, store the image embeddings, otherwise the hidden states
@@ -230,6 +231,10 @@ class BaseAlgo(ABC):
             delta = self.rewards[i] + self.discount * next_value * next_mask - self.values[i]
             self.advantages[i] = delta + self.discount * self.gae_lambda * next_advantage * next_mask
 
+            # undiscounted return / rewards to go (not used by all algos)
+            next_reward_togo = self.rewards_togo[i+1] if i < self.num_frames_per_proc - 1 else next_value
+            self.rewards_togo[i] = self.rewards[i] + next_reward_togo * next_mask
+
         # Define experiences:
         #   the whole experience is the concatenation of the experience
         #   of each process.
@@ -260,6 +265,9 @@ class BaseAlgo(ABC):
         # Preprocess experiences
 
         exps.obs = self.preprocess_obss(exps.obs, device=self.device)
+
+        # TODO remove, for debugging only
+        self.exps = exps
 
         # Log some values
 

--- a/rl_credit/examples/train.py
+++ b/rl_credit/examples/train.py
@@ -91,7 +91,7 @@ def train(env_id,
 
     # Load model
     use_mem = recurrence > 1
-    if algo_name == 'a2c':
+    if algo_name in ('a2c', 'attentionq'):
         acmodel = ACModel(obs_space, envs[0].action_space, use_mem, False)
     else:
         raise ValueError("Unrecognized algo")
@@ -111,6 +111,8 @@ def train(env_id,
                         'preprocess_obss': preprocess_obss})
     if algo_name == 'a2c':
         algo = rl_credit.A2CAlgo(**algo_kwargs)
+    elif algo_name == 'attentionq':
+        algo = rl_credit.AttentionQAlgo(**algo_kwargs)
 
     if "optimizer_state" in status:
         algo.optimizer.load_state_dict(status["optimizer_state"])
@@ -197,3 +199,4 @@ def train(env_id,
 
     # At end of run, copy model dir into wandb dir (includes csv logs and model dict)
     shutil.copytree(model_dir, os.path.join(wandb_dir, 'model'))
+    return algo  # for interactive debugging

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -613,10 +613,15 @@ class QAttentionModel(nn.Module):
         self.Wk = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
         self.Wv = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
 
+        # self.Qvalue = nn.Sequential(
+        #     nn.Linear(d_key, 64),
+        #     nn.ReLU(),
+        #     nn.Linear(64, 1)
+        # )
         self.Qvalue = nn.Sequential(
             nn.Linear(d_key, 64),
             nn.ReLU(),
-            nn.Linear(64, 1)
+            nn.Linear(64, 2)
         )
 
     def forward(self, obs, act, mask_future=True, custom_mask=None):
@@ -659,6 +664,7 @@ class QAttentionModel(nn.Module):
         attn_out = torch.bmm(scores, values)   # batch_sz x seq_len x d_key
 
         x = self.Qvalue(attn_out.view(batch_sz * seq_len, self.d_key))
-        qvalue = x.squeeze(1)
+        #qvalue = x.squeeze(1)
 
-        return qvalue, scores
+        #return qvalue, scores
+        return x, scores

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -112,6 +112,7 @@ class ACModel(nn.Module, RecurrentACModel):
         x = obs.image.transpose(1, 3).transpose(2, 3)
         x = self.image_conv(x)
         x = x.reshape(x.shape[0], -1)
+        image_embedding = x
 
         if self.use_memory:
             hidden = (memory[:, :self.semi_memory_size], memory[:, self.semi_memory_size:])
@@ -132,10 +133,7 @@ class ACModel(nn.Module, RecurrentACModel):
         value = x.squeeze(1)
 
         if self.return_embedding:
-            # if no memory, embedding is the img embedding, otherwise
-            # it's the hidden state of the LSTM, also (redundantly) stored
-            # in memory.
-            return dist, value, memory, embedding
+            return dist, value, memory, image_embedding
         else:
             return dist, value, memory
 

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -623,7 +623,7 @@ class QAttentionModel(nn.Module):
         self.Qvalue = nn.Sequential(
             nn.Linear(d_key, 64),
             nn.ReLU(),
-            nn.Linear(64, 2)
+            nn.Linear(64, 1)
         )
 
     def forward(self, obs, act, mask_future=True, custom_mask=None):

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -604,12 +604,16 @@ class QAttentionModel(nn.Module):
 
         self.d_key = d_key
 
-        self._action_embed_size = 32
-        self.action_embed = nn.Linear(action_size, self._action_embed_size)
+        # self._action_embed_size = 32
+        # self.action_embed = nn.Linear(action_size, self._action_embed_size)
 
-        self.Wq = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
-        self.Wk = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
-        self.Wv = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
+        # self.Wq = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
+        # self.Wk = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
+        # self.Wv = nn.Linear(embedding_size + self._action_embed_size, d_key, bias=False)
+
+        self.Wq = nn.Linear(embedding_size, d_key, bias=False)
+        self.Wk = nn.Linear(embedding_size, d_key, bias=False)
+        self.Wv = nn.Linear(embedding_size, d_key, bias=False)
 
         # self.Qvalue = nn.Sequential(
         #     nn.Linear(d_key, 64),
@@ -640,9 +644,9 @@ class QAttentionModel(nn.Module):
         """
         batch_sz, seq_len, _ = obs.shape
 
-        action_embedding = self.action_embed(act.reshape(batch_sz * seq_len, -1))
+        #action_embedding = self.action_embed(act.reshape(batch_sz * seq_len, -1))
 
-        x = torch.cat((obs.reshape(batch_sz * seq_len, -1), action_embedding), dim=1)
+        x = obs.reshape(batch_sz * seq_len, -1)
 
         # batch_sz x seq_len x d_key
         queries = self.Wq(x).view(batch_sz, seq_len, self.d_key) / (self.d_key ** (1/4))


### PR DESCRIPTION
First pass temporal value transport
- Model is a binary classifier with attention layer that tries to predict if returns are above some high threshold.  Use weights from attention layer to define "importance" for TVT.
- For all obs with importance above a threshold (hyperparam), modify their advantage with TVT rewards defined as `*alpha*importance*rewards_to_go`

TODOs:
- model only takes image embedding, consider trying action and hidden state embeddings.  Rename it (no longer trying to learn a Qvalue)
- no exclusion zone implemented for TVT
- classifier should predict rewards to go instead of returns (since the threshold is set according to the rewards to go -- this may help with frames earlier in the episode whose returns are reduced by discounting currently)
- modify training scripts/ examples to be compatible with the args expected by this algo