### PR TITLE
Rew2go tvt

### DIFF
--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -29,7 +29,8 @@ class AttentionQAlgo(BaseAlgo):
                  gae_lambda=0.95, entropy_coef=0.01, value_loss_coef=0.5, max_grad_norm=0.5,
                  recurrence=4, rmsprop_alpha=0.99, rmsprop_eps=1e-8, preprocess_obss=None,
                  reshape_reward=None, wandb_dir=None, d_key=30, use_tvt=True,
-                 importance_threshold=0.05, tvt_alpha=0.9, y_moving_avg_alpha=0.1, pos_weight=2):
+                 importance_threshold=0.05, tvt_alpha=0.9, y_moving_avg_alpha=0.1, pos_weight=2,
+                 embed_actions=False):
         num_frames_per_proc = num_frames_per_proc or 8
 
         super().__init__(envs, acmodel, device, num_frames_per_proc, discount, lr, gae_lambda, entropy_coef,
@@ -40,7 +41,8 @@ class AttentionQAlgo(BaseAlgo):
         embed_size = self.acmodel.semi_memory_size
         self.qmodel = QAttentionModel(embedding_size=embed_size,
                                       action_size=7,
-                                      d_key=d_key)
+                                      d_key=d_key,
+                                      embed_actions=embed_actions)
 
         self.optimizer = torch.optim.RMSprop(self.acmodel.parameters(), lr,
                                              alpha=rmsprop_alpha, eps=rmsprop_eps)

--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -295,7 +295,7 @@ class AttentionQAlgo(BaseAlgo):
                                      mask_future=True,
                                      custom_mask=self.attn_mask)
 
-        y_target = (exps.returnn > self.y_max_return).float().unsqueeze(1)
+        y_target = (exps.rewards_togo > self.y_max_return).float().unsqueeze(1)
         pos_weight = torch.tensor([2])
         qvalue_loss = F.binary_cross_entropy_with_logits(qvalue, y_target, pos_weight=pos_weight)
 

--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -318,7 +318,7 @@ class AttentionQAlgo(BaseAlgo):
         # Log some values
 
         # Save attention scores heatmap every 200 updates
-        if self.wandb_dir is not None and self._update_number % 200 == 0:
+        if self.wandb_dir is not None and self._update_number % 100 == 0:
             self.save_attention_plots(scores)
             self.save_top_attended_obs(k=10)
 
@@ -399,9 +399,11 @@ class AttentionQAlgo(BaseAlgo):
                        5: 'toggle',
                        6: 'done'}
 
+        sorted_top_imp, sorted_idxs = torch.sort(self.top_imp, descending=True)
+
         for i in range(min(k, len(self.top_imp))):
-            proc, frame = self.top_imp_idxs[i]
-            score = str(self.top_imp[i].numpy().round(2))
+            proc, frame = self.top_imp_idxs[sorted_idxs[i]]
+            score = str(sorted_top_imp[i].numpy().round(2))
             act = map_actions[self.actions[frame, proc].item()]
             fname = f'obs_{self._update_number:04}_proc{proc}_fr{frame:03}_score{score}__{act}.png'
 

--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -256,6 +256,7 @@ class BaseAlgo(ABC):
         exps.action = self.actions.transpose(0, 1).reshape(-1)
         exps.value = self.values.transpose(0, 1).reshape(-1)
         exps.reward = self.rewards.transpose(0, 1).reshape(-1)
+        exps.rewards_togo = self.rewards_togo.transpose(0, 1).reshape(-1)  # only used by TVT
         exps.advantage = self.advantages.transpose(0, 1).reshape(-1)
         exps.returnn = exps.value + exps.advantage
         # normalize the advantage


### PR DESCRIPTION
- Use rewards to go instead of discounted returns for classification (since threshold is set relative to max returns per episode)
- make embedding actions an option in attention model
- make positive class weight a kwarg instead of harcoded to 2
- bugfix - handle case when there are no obs w/ importance > importance thresh