### PR TITLE
Put tensor on cpu before numpy convert for plots

### DIFF
--- a/rl_credit/examples/train.py
+++ b/rl_credit/examples/train.py
@@ -56,6 +56,9 @@ def train(env_id,
     # set run dir
     model_dir = utils.get_model_dir(model_dir_stem)
 
+    # set plots output dir, only for attention model
+    plots_dir = model_dir
+
     # Load loggers
     txt_logger = utils.get_txt_logger(model_dir)
     csv_file, csv_logger = utils.get_csv_logger(model_dir)
@@ -112,7 +115,7 @@ def train(env_id,
     if algo_name == 'a2c':
         algo = rl_credit.A2CAlgo(**algo_kwargs)
     elif algo_name == 'attentionq':
-        algo = rl_credit.AttentionQAlgo(**algo_kwargs)
+        algo = rl_credit.AttentionQAlgo(**algo_kwargs, plots_dir=plots_dir)
 
     if "optimizer_state" in status:
         algo.optimizer.load_state_dict(status["optimizer_state"])

--- a/rl_credit/scripts/train.py
+++ b/rl_credit/scripts/train.py
@@ -196,7 +196,7 @@ elif args.algo == "attention":
 elif args.algo == "attentionq":
     algo = rl_credit.AttentionQAlgo(envs, acmodel, device, args.frames_per_proc, args.discount, args.lr, args.gae_lambda,
                                     args.entropy_coef, args.value_loss_coef, args.max_grad_norm, args.recurrence,
-                                    args.optim_alpha, args.optim_eps, preprocess_obss, wandb_dir=wandb_dir,
+                                    args.optim_alpha, args.optim_eps, preprocess_obss, plots_dir=wandb_dir,
                                     d_key=args.d_key)
 else:
     raise ValueError("Incorrect algorithm name: {}".format(args.algo))


### PR DESCRIPTION
Also supply plots_dir instead of wandb_dir for outputting plots.  Using wandb.run.dir does not seem to work on Azure, but copying plots into storage/ along with model and then moving to wandb_dir at end of run seems more reliable in cloud