### PR TITLE
Rew2go tvt

### DIFF
--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -103,47 +103,40 @@ class AttentionQAlgo(BaseAlgo):
         top_rew2go = self.get_top_rew2go(self.top_imp_idxs)
         #top_rew2go = self.rewards_togo.transpose(0,1)[importance_mask]
 
-        if len(self.top_imp) > 0:
+        # TVT: add undiscounted rewards-to-go, excluding rewards accumulated during discount time
+        # scale, to the most important obs and recalculate advantages with these new values.
+        if len(self.top_imp) > 0 and self.use_tvt:
             # logging
             tvt_rewards = []
 
-            self.tvt_advantages = self.advantages.clone().detach()
-
-            # Modify the advantages of the most important obs by adding the undiscounted
-            # rewards-to-go to their advantage
             for idx, weight, tvt_val in zip(self.top_imp_idxs, self.top_imp, top_rew2go):
                 proc, frame = idx
                 tvt_reward = tvt_val * self.tvt_alpha * weight
-                self.tvt_advantages[frame, proc] += tvt_reward
+                self.values[frame, proc] += tvt_reward
                 tvt_rewards.append(tvt_reward.item())
 
-            if self.use_tvt:
-                exps.advantage = self.tvt_advantages.transpose(0,1).reshape(-1)
-                exps.advantage = (exps.advantage - exps.advantage.mean())/exps.advantage.std()
+            self.calculate_advantages()
+            exps.advantage = self.advantages.transpose(0,1).reshape(-1)
+            exps.advantage = (exps.advantage - exps.advantage.mean())/exps.advantage.std()
 
             tvt_rewards = np.array(tvt_rewards)
+            logs.update({'tvt_reward_max': tvt_rewards.max(),
+                         'tvt_reward_mean': tvt_rewards.mean(),
+                         'tvt_reward_min': tvt_rewards.min(),
+            })
+
+        # Log some values
+        if len(self.top_imp) > 0:
             logs.update({'top_scores_max': self.top_imp.max().item(),
                          'top_scores_mean': self.top_imp.mean().item(),
                          'top_scores_min': self.top_imp.min().item(),
                          'top_rew2go_max': top_rew2go.max().item(),
                          'top_rew2go_mean': top_rew2go.mean().item(),
                          'top_rew2go_min': top_rew2go.min().item(),
-                         'tvt_reward_max': tvt_rewards.max(),
-                         'tvt_reward_mean': tvt_rewards.mean(),
-                         'tvt_reward_min': tvt_rewards.min(),
-                         'adv_tvt_max': self.tvt_advantages.max().item(),
-                         'adv_tvt_min': self.tvt_advantages.min().item(),
-                         'adv_tvt_mean': self.tvt_advantages.mean().item(),
-                         'adv_tvt_std': self.tvt_advantages.std().item(),
-                         'num_obs_over_tvt_thresh': len(self.top_imp),
             })
 
-        # Log some values
         logs.update({'return_classifier_thresh': self.y_max_return,
-                     "adv_max": self.advantages.max().item(),
-                     "adv_min": self.advantages.min().item(),
-                     "adv_mean": self.advantages.mean().item(),
-                     "adv_std": self.advantages.std().item(),
+                     'num_obs_over_tvt_thresh': len(self.top_imp),
         })
 
         return exps, logs

--- a/rl_credit/algos/attention_qvalue.py
+++ b/rl_credit/algos/attention_qvalue.py
@@ -85,8 +85,7 @@ class AttentionQAlgo(BaseAlgo):
 
         # Update max returns (moving average) seen in training run
         max_return = max(logs['return_per_episode'])  # undiscounted returns
-        if max_return > self.y_max_return:
-            self.y_max_return += self.y_moving_avg_alpha * (max_return - self.y_max_return)
+        self.y_max_return += self.y_moving_avg_alpha * (max_return - self.y_max_return)
 
         # ===== Use most highly attended observations for TVT =====
 

--- a/rl_credit/algos/base.py
+++ b/rl_credit/algos/base.py
@@ -292,13 +292,15 @@ class BaseAlgo(ABC):
     def update_parameters(self):
         pass
 
-    def calculate_advantages(self):
+    def calculate_advantages(self, rewards=None):
         next_value = self.value
+        if rewards is None:
+            rewards = self.rewards
 
         for i in reversed(range(self.num_frames_per_proc)):
             next_mask = self.masks[i+1] if i < self.num_frames_per_proc - 1 else self.mask
             next_value = self.values[i+1] if i < self.num_frames_per_proc - 1 else next_value
             next_advantage = self.advantages[i+1] if i < self.num_frames_per_proc - 1 else 0
 
-            delta = self.rewards[i] + self.discount * next_value * next_mask - self.values[i]
+            delta = rewards[i] + self.discount * next_value * next_mask - self.values[i]
             self.advantages[i] = delta + self.discount * self.gae_lambda * next_advantage * next_mask

--- a/rl_credit/examples/__init__.py
+++ b/rl_credit/examples/__init__.py
@@ -17,6 +17,11 @@ register(
 )
 
 register(
+    id='GiftDistractorDelay2-v0',
+    entry_point='rl_credit.examples.distractor_delay_expt:Delay2_Gifts'
+)
+
+register(
     id='GiftDistractorReward0-v0',
     entry_point='rl_credit.examples.distractor_mean_expt:Reward0_Gifts'
 )

--- a/rl_credit/examples/distractor_delay_expt.py
+++ b/rl_credit/examples/distractor_delay_expt.py
@@ -30,6 +30,12 @@ class Delay1_Gifts(VaryGiftsGoalEnv):
         super().__init__(distractor_xtra_kwargs)
 
 
+class Delay2_Gifts(VaryGiftsGoalEnv):
+    def __init__(self):
+        distractor_xtra_kwargs = {'max_steps': 2.0 * DISCOUNT_TIMESCALE}
+        super().__init__(distractor_xtra_kwargs)
+
+
 ####################################################
 # Config params shared among all experiments
 
@@ -86,16 +92,29 @@ common_algo_kwargs = dict(
 
 
 ##************ experiment 3 ************
-model_dir_stem='a2c_mem10_giftdelay1'
+# model_dir_stem='a2c_mem10_giftdelay1'
+# expt_train_config = dict(
+#     env_id='GiftDistractorDelay1-v0',
+#     algo_name='a2c',
+#     recurrence=10,
+# )
+# expt_algo_kwargs = {}
+# delay_factor = 'delay_factor=1'
+# delay_steps = 'delay_steps=100'
+# wandb_notes = 'A2C with recurrence=10, gift env delay=100 steps (100% of discount factor timescale)'
+
+
+##************ experiment 4 ************
+model_dir_stem='a2c_mem10_giftdelay2'
 expt_train_config = dict(
-    env_id='GiftDistractorDelay1-v0',
+    env_id='GiftDistractorDelay2-v0',
     algo_name='a2c',
     recurrence=10,
 )
 expt_algo_kwargs = {}
-delay_factor = 'delay_factor=1'
-delay_steps = 'delay_steps=100'
-wandb_notes = 'A2C with recurrence=10, gift env delay=100 steps (100% of discount factor timescale)'
+delay_factor = 'delay_factor=2'
+delay_steps = 'delay_steps=200'
+wandb_notes = 'A2C with recurrence=10, gift env delay=200 steps (200% of discount factor timescale)'
 
 
 def main(seed):

--- a/rl_credit/examples/environment.py
+++ b/rl_credit/examples/environment.py
@@ -25,7 +25,6 @@ class KeyGiftsGoalBaseEnv(ThreePhaseDelayedReward):
             delayed_reward_env=GoalKeyOptionalEnv,
             delayed_reward_kwargs=dict(
                 size=7,
-                key_color=None,
                 max_steps=100,
                 goal_reward=5.,
                 key_reward=15.,


### PR DESCRIPTION
- Exclude rewards to go rewards in the near term, over time scale set by discount period.  This is to avoid "double counting"
- Add the temporally transported rewards to the *rewards* instead of GAE advantages -- which (1) should be less disruptive than adding to advantages directly, (2) is more natural from the point of view of standard bootstrapping values, (3) allows GAE-lambda to help "spill over" the benefit of an action in a single obs, e.g. important when sequences of obs are important, not a single (obs, action) pair as in this artificial env.
- Add delay=200 steps environment

TODOs:
- cap max thresh at some point (when testing out, hard coded to known value near max)