### PR TITLE
Expts fix time in phase3 to 70

### DIFF
--- a/rl_credit/examples/environment.py
+++ b/rl_credit/examples/environment.py
@@ -7,6 +7,7 @@ from gym_minigrid.envs.goalkeyoptional import GoalKeyOptionalEnv
 DISCOUNT_FACTOR = 0.99
 DISCOUNT_TIMESCALE = 100
 STEPS_IN_PHASE1 = 30
+STEPS_IN_PHASE3 = 70
 
 
 class KeyGiftsGoalBaseEnv(ThreePhaseDelayedReward):
@@ -25,9 +26,10 @@ class KeyGiftsGoalBaseEnv(ThreePhaseDelayedReward):
             delayed_reward_env=GoalKeyOptionalEnv,
             delayed_reward_kwargs=dict(
                 size=7,
-                max_steps=100,
+                max_steps=STEPS_IN_PHASE3,
                 goal_reward=5.,
                 key_reward=15.,
+                done_when_goal_reached=False,
             ),
             key_teleports_to_end_only=True
         )


### PR DESCRIPTION
Steps in phase 1 are already fixed to 30.

This makes it easier to have parallel complete episode collection (just need to set num_frames_per_proc during training equal to a multiple of the constant total steps per 3-phase episode).