### PR TITLE
Explicitly initialize params in attention model

### DIFF
--- a/rl_credit/examples/distractor_delay_expt.py
+++ b/rl_credit/examples/distractor_delay_expt.py
@@ -121,7 +121,7 @@ common_algo_kwargs = dict(
 model_dir_stem='tvt_mem10_giftdelay2'
 expt_train_config = dict(
     env_id='GiftDistractorDelay2-v0',
-    algo_name='attentionq',
+    algo_name='tvt',
     recurrence=10,
 )
 expt_algo_kwargs = dict(

--- a/rl_credit/examples/train.py
+++ b/rl_credit/examples/train.py
@@ -94,7 +94,7 @@ def train(env_id,
 
     # Load model
     use_mem = recurrence > 1
-    if algo_name in ('a2c', 'attentionq'):
+    if algo_name in ('a2c', 'tvt'):
         acmodel = ACModel(obs_space, envs[0].action_space, use_mem, False)
     else:
         raise ValueError("Unrecognized algo")
@@ -114,7 +114,7 @@ def train(env_id,
                         'preprocess_obss': preprocess_obss})
     if algo_name == 'a2c':
         algo = rl_credit.A2CAlgo(**algo_kwargs)
-    elif algo_name == 'attentionq':
+    elif algo_name == 'tvt':
         algo = rl_credit.AttentionQAlgo(**algo_kwargs, plots_dir=plots_dir)
 
     if "optimizer_state" in status:

--- a/rl_credit/model.py
+++ b/rl_credit/model.py
@@ -623,6 +623,7 @@ class QAttentionModel(nn.Module):
             nn.ReLU(),
             nn.Linear(64, 1)
         )
+        self.apply(init_params)
 
     def forward(self, obs, act, mask_future=True, custom_mask=None):
         """

--- a/rl_credit/scripts/train.py
+++ b/rl_credit/scripts/train.py
@@ -161,7 +161,7 @@ elif args.algo == "hca_state":
     acmodel = ACModelStateHCA(obs_space, envs[0].action_space)
 elif args.algo == "attention":
     acmodel = ACAttention(obs_space, envs[0].action_space, d_key=args.d_key)
-elif args.algo == "attentionq":
+elif args.algo == "tvt":
     acmodel = ACModel(obs_space, envs[0].action_space, args.mem, args.text)
 else:
     acmodel = ACModel(obs_space, envs[0].action_space, args.mem, args.text)
@@ -193,7 +193,7 @@ elif args.algo == "attention":
     algo = rl_credit.AttentionAlgo(envs, acmodel, device, args.frames_per_proc, args.discount, args.lr, args.gae_lambda,
                                    args.entropy_coef, args.value_loss_coef, args.max_grad_norm, args.recurrence,
                                    args.optim_alpha, args.optim_eps, preprocess_obss, wandb_dir=wandb_dir)
-elif args.algo == "attentionq":
+elif args.algo == "tvt":
     algo = rl_credit.AttentionQAlgo(envs, acmodel, device, args.frames_per_proc, args.discount, args.lr, args.gae_lambda,
                                     args.entropy_coef, args.value_loss_coef, args.max_grad_norm, args.recurrence,
                                     args.optim_alpha, args.optim_eps, preprocess_obss, plots_dir=wandb_dir,


### PR DESCRIPTION
Does better than using default params:

e.g. run set with default params "default-init-tvt|mem=10|GiftDistractorDelay2-v0" compared to explicit init "tvt|mem=10|GiftDistractorDelay2-v0" in [distractor gift time delay](https://app.wandb.ai/frangipane/distractor_time_delays/reports/Distractor-Gift-time-delay--VmlldzoxMjYyNzY) experiments.